### PR TITLE
Slack scopes migration

### DIFF
--- a/src/open_company_auth/slack.clj
+++ b/src/open_company_auth/slack.clj
@@ -12,7 +12,7 @@
 (def ^:private slack {
   :redirectURI  "/slack-oauth"
   :state        "open-company-auth"
-  :scope        "identify,read,post"})
+  :scope        "users:read"})
 
 (def ^:private slack-url (str
   "https://slack.com/oauth/authorize?client_id="


### PR DESCRIPTION
card: https://trello.com/c/TTSFF6gT

Migrate slack scopes: _identify,read,post_ -> _users:read_
The only call that requires a scope is users.info and from this table https://api.slack.com/docs/oauth-scopes the required new scope is _users:read_

NB: we used to have post privileges but at this point i can't say which scopes we are going to need until i know which API we are going to use.

Test:
- remove the jwt if you have one
- authenticate with our auth service
- check if you have write privileges
- merge
