### PR TITLE
Persist bot relevant info in jwtoken

### DIFF
--- a/opt/identities/camus.edn
+++ b/opt/identities/camus.edn
@@ -7,4 +7,5 @@
   :owner true
   :admin true
   :org-id "slack:98765"
+  :bot {:id "abc" :token "xyz"}
 }

--- a/src/open_company_auth/slack.clj
+++ b/src/open_company_auth/slack.clj
@@ -71,7 +71,6 @@
         org          {:org-id   (str prefix (:team_id response))
                       :org-name (:team response)}
         access-token (:access_token response)]
-    (prn response)
     (try
       (test-access-token access-token)
       (if (:ok response)

--- a/src/open_company_auth/slack.clj
+++ b/src/open_company_auth/slack.clj
@@ -79,13 +79,13 @@
                                         config/slack-client-secret
                                         slack-code
                                         (str config/auth-server-url (:redirectURI slack)))
-        bot          {:bot-id    (-> response :bot :bot_user_id)
-                      :bot-token (-> response :bot :bot_access_token)}
+        bot          {:bot {:id    (-> response :bot :bot_user_id)
+                            :token (-> response :bot :bot_access_token)}}
         access-token (:access_token response)]
     (try
       (if (:ok response)
         (let [jwt-data (test-access-token (:access_token response))]
-          [true (jwt/generate (assoc jwt-data :bot bot))])
+          [true (jwt/generate (merge jwt-data bot))])
         (throw (ex-info "Invalid slack code" {:response response})))
       (catch Throwable e
         [false (.getMessage e)]))))

--- a/src/open_company_auth/slack.clj
+++ b/src/open_company_auth/slack.clj
@@ -65,7 +65,7 @@
         org      {:org-id org-id :org-name org-name}]
     (if (:ok response)
       (jwt-data (get-user-info access-token org user-id))
-      (throw (ex-info "Eroor while testing access token"
+      (throw (ex-info "Error while testing access token"
                       {:response response})))))
 
 (defn- swap-code-for-token

--- a/src/open_company_auth/slack.clj
+++ b/src/open_company_auth/slack.clj
@@ -28,28 +28,29 @@
 
 (def auth-settings (merge {:full-url slack-url} slack))
 
-(defn- jwt-token-for
+(defn- jwt-data
   "Given user, profile and org data, package it up into a map and encode it as a JWToken."
-  [user profile org]
-  (let [jwt-content {
-          :user-id (str prefix (:id user))
-          :name (:name user)
-          :real-name (:real_name profile)
-          :avatar (:image_192 profile)
-          :email (:email profile)
-          :owner (:is_owner user)
-          :admin (:is_admin user)}]
-    [true (jwt/generate (merge org jwt-content))]))
+  [{:keys [user profile org]}]
+  {:pre [(map? user) (map? profile) (map? org)]}
+  (let [jwt-content {:user-id (str prefix (:id user))
+                     :name (:name user)
+                     :real-name (:real_name profile)
+                     :avatar (:image_192 profile)
+                     :email (:email profile)
+                     :owner (:is_owner user)
+                     :admin (:is_admin user)}]
+    (merge org jwt-content)))
 
-(defn- user-info-for
+(defn- get-user-info
   "Given a Slack access token, retrieve the user info from Slack for the specified user id."
   [access-token org user-id]
   (let [user-info (slack-users/info (merge slack-connection {:token access-token}) user-id)
         user (:user user-info)
         profile (:profile user)]
     (if (:ok user-info)
-      (jwt-token-for user profile org)
-      [false "user-info-error"])))
+      {:user user :profile profile :org org}
+      (throw (ex-info "Error response from Slack API while retrieving user data"
+                      {:response user-info :user-id user-id :org org})))))
 
 (defn- test-access-token
   "
@@ -58,13 +59,14 @@
   "
   [access-token]
   (let [response (slack-auth/test (merge slack-connection {:token access-token}))
-        user-id (:user_id response)
-        org-id (str prefix (:team_id response))
+        user-id  (:user_id response)
+        org-id   (str prefix (:team_id response))
         org-name (:team response)
-        org {:org-id org-id :org-name org-name}]
+        org      {:org-id org-id :org-name org-name}]
     (if (:ok response)
-      (user-info-for access-token org user-id)
-      [false "test-call-error"])))
+      (jwt-data (get-user-info access-token org user-id))
+      (throw (ex-info "Eroor while testing access token"
+                      {:response response})))))
 
 (defn- swap-code-for-token
   "
@@ -72,15 +74,21 @@
   If the swap works, then test the access token.
   "
   [slack-code]
-  (let [parsed-body (slack-oauth/access slack-connection
+  (let [response     (slack-oauth/access slack-connection
                                         config/slack-client-id
                                         config/slack-client-secret
                                         slack-code
                                         (str config/auth-server-url (:redirectURI slack)))
-        access-token (:access_token parsed-body)]
-    (if (:ok parsed-body)
-      (test-access-token access-token)
-      [false "invalid-slack-code"])))
+        bot          {:bot-id    (-> response :bot :bot_user_id)
+                      :bot-token (-> response :bot :bot_access_token)}
+        access-token (:access_token response)]
+    (try
+      (if (:ok response)
+        (let [jwt-data (test-access-token (:access_token response))]
+          [true (jwt/generate (assoc jwt-data :bot bot))])
+        (throw (ex-info "Invalid slack code" {:response response})))
+      (catch Throwable e
+        [false (.getMessage e)]))))
 
 (defun oauth-callback
   "


### PR DESCRIPTION
The purpose of this PR is to add the bot token to the users jwtoken so we can use the users action on the platform to trigger things inside Slack/make our bot join their slack team. [trello](https://trello.com/c/f0dln1Pi/134-initial-slackbot)

Lots of changes, just realized again and again that things could be simplified.

old token

``` clojure
{:email "martinklepsch@googlemail.com"
 :admin false
 :owner false
 :org-id "slack:T06SBMH60"
 :org-name "OpenCompany"
 :user-id "slack:U0JSATHT3"
 :name "martin"
 :real-name "Martin Klepsch"
 :avatar
 "https://secure.gravatar.com/avatar/746d139f9b7c20f00641fd91bd26b451.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-192.png"}
```

new token (note last line

``` clojure
{:email "martinklepsch@googlemail.com"
 :admin false
 :owner false
 :org-id "slack:T06SBMH60"
 :org-name "OpenCompany"
 :user-id "slack:U0JSATHT3"
 :name "martin"
 :real-name "Martin Klepsch"
 :avatar
 "https://secure.gravatar.com/avatar/746d139f9b7c20f00641fd91bd26b451.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-192.png"
 :bot {:id "U10AR0H50" :token "xoxb-..."}}
```
