### PR TITLE
Provide auth-url and extended-scopes-url in auth-settings

### DIFF
--- a/src/open_company_auth/slack.clj
+++ b/src/open_company_auth/slack.clj
@@ -9,24 +9,25 @@
 (def ^:private slack-endpoint "https://slack.com/api")
 (def ^:private slack-connection {:api-url slack-endpoint})
 
-(def ^:private slack {
-  :redirectURI  "/slack-oauth"
-  :state        "open-company-auth"
-  :scope        "users:read"})
+(def ^:private slack
+  {:redirectURI  "/slack-oauth"
+   :state        "open-company-auth"})
 
-(def ^:private slack-url (str
-  "https://slack.com/oauth/authorize?client_id="
-  config/slack-client-id
-  "&redirect_uri="
-  config/auth-server-url (:redirectURI slack)
-  "&state="
-  (:state slack)
-  "&scope="
-  (:scope slack)))
+(defn- slack-auth-url [scope]
+  (str "https://slack.com/oauth/authorize?client_id="
+       config/slack-client-id
+       "&redirect_uri="
+       config/auth-server-url (:redirectURI slack)
+       "&state="
+       (:state slack)
+       "&scope="
+       scope))
 
 (def ^:private prefix "slack:")
 
-(def auth-settings (merge {:full-url slack-url} slack))
+(def auth-settings (merge {:auth-url            (slack-auth-url "users:read")
+                           :extended-scopes-url (slack-auth-url "bot,users:read")}
+                          slack))
 
 (defn- get-user-info
   "Given a Slack access token, retrieve the user info from Slack for the specified user id."

--- a/test/open_company_auth/test.clj
+++ b/test/open_company_auth/test.clj
@@ -13,8 +13,8 @@
           body (json/parse-string (:body resp))]
       (:status resp) => 200
       (test-utils/response-mime-type resp) => "application/json"
-      (contains? body "full-url") => true
-      (> (count (body "full-url")) 0) => true
+      (contains? body "auth-url") => true
+      (> (count (body "auth-url")) 0) => true
       (contains? body "scope") => true))
   (fact "hit /slack-oauth"
     (let [resp (test-utils/api-request :get "/slack-oauth?code=test&test=true" {})

--- a/test/open_company_auth/test.clj
+++ b/test/open_company_auth/test.clj
@@ -14,8 +14,7 @@
       (:status resp) => 200
       (test-utils/response-mime-type resp) => "application/json"
       (contains? body "auth-url") => true
-      (> (count (body "auth-url")) 0) => true
-      (contains? body "scope") => true))
+      (> (count (body "auth-url")) 0) => true))
   (fact "hit /slack-oauth"
     (let [resp (test-utils/api-request :get "/slack-oauth?code=test&test=true" {})
           body (json/parse-string (:body resp))]


### PR DESCRIPTION
This is required to implement the improved signup flow where users initially just authenticate. If there owners they will be asked to grant access to the bot.

This is based on #4, I'll rebase once #4  is merged.

**To test**
- open web
- sign in
- sign out

Essentially everything should work just the same as before. The `:extended-scopes-url` isn't used yet but will be as soon as we start handling the case of users not being permitted to add integrations to their team.

Necessary change to web is here: https://github.com/open-company/open-company-web/pull/121
