### PR TITLE
Slack onboarding

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,10 +18,10 @@
     [defun "0.3.0-RC1"] ; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     [ring/ring-devel "1.6.0-beta6"] ; Web application library https://github.com/ring-clojure/ring
     [ring/ring-core "1.6.0-beta6"] ; Web application library https://github.com/ring-clojure/ring
-    [compojure "1.6.0-beta1"] ; A concise routing library for Ring/Clojure https://github.com/weavejester/compojure
+    [compojure "1.6.0-beta2"] ; A concise routing library for Ring/Clojure https://github.com/weavejester/compojure
     [commons-codec "1.10" :exclusions [[org.clojure/clojure]]] ; Dependency of compojure, ring-core, and midje http://commons.apache.org/proper/commons-codec/
     [http-kit "2.3.0-alpha1"] ; Web server http://http-kit.org/
-    [com.stuartsierra/component "0.3.1"] ; Component Lifecycle
+    [com.stuartsierra/component "0.3.2"] ; Component Lifecycle
     [prismatic/schema "1.1.3"] ; Data validation https://github.com/Prismatic/schema
     [cheshire "5.6.3"] ; JSON encoder/decoder https://github.com/dakrone/cheshire
     [com.apa512/rethinkdb "0.15.26"] ; RethinkDB client for Clojure https://github.com/apa512/clj-rethinkdb
@@ -33,12 +33,12 @@
     [jumblerg/ring.middleware.cors "1.0.1"] ; CORS library https://github.com/jumblerg/ring.middleware.cors
     [clj-jwt "0.1.1"] ; Clojure library for JSON Web Token (JWT) https://github.com/liquidz/clj-jwt
     [org.clojure/tools.cli "0.3.5"] ; command-line parsing https://github.com/clojure/tools.cli
-    [com.taoensso/timbre "4.8.0-alpha1"] ; logging https://github.com/ptaoussanis/timbre
+    [com.taoensso/timbre "4.8.0"] ; logging https://github.com/ptaoussanis/timbre
     [alandipert/enduro "1.2.0"] ; Durable atoms https://github.com/alandipert/enduro
-    [clj-time "0.12.2"] ; JodaTime wrapper https://github.com/clj-time/clj-time
+    [clj-time "0.13.0"] ; JodaTime wrapper https://github.com/clj-time/clj-time
     [com.taoensso/truss "1.3.6"] ; Assertions w/ great errors https://github.com/ptaoussanis/truss
     [open-company/lib "0.0.6-04c024d"] ; Library for OC projects https://github.com/open-company/open-company-lib
-    [amazonica "0.3.77"] ; A comprehensive Clojure client for the entire Amazon AWS api https://github.com/mcohen01/amazonica
+    [amazonica "0.3.81"] ; A comprehensive Clojure client for the entire Amazon AWS api https://github.com/mcohen01/amazonica
   ]
 
   :plugins [
@@ -61,7 +61,7 @@
       :plugins [
         [lein-midje "3.2.1"] ; Example-based testing https://github.com/marick/lein-midje
         [jonase/eastwood "0.2.3"] ; Clojure linter https://github.com/jonase/eastwood
-        [lein-kibit "0.1.2"] ; Static code search for non-idiomatic code https://github.com/jonase/kibit
+        [lein-kibit "0.1.3"] ; Static code search for non-idiomatic code https://github.com/jonase/kibit
       ]
     }
 

--- a/src/oc/auth/slack.clj
+++ b/src/oc/auth/slack.clj
@@ -189,7 +189,7 @@
   (let [conn      (merge slack-connection {:token bot-token})
         channels  (slack/slack-request conn "channels.list")]
     (if (:ok channels)
-      (filter #(not (:is_archived %)) (:channels channels)) ; unarchived channels
+      (remove :is_archived (:channels channels)) ; unarchived channels
       (do (timbre/warn "Channel list could not be retrieved."
                        {:response channels :bot-token bot-token})
           false))))

--- a/src/oc/auth/slack.clj
+++ b/src/oc/auth/slack.clj
@@ -37,12 +37,12 @@
 
 (defn user-url [org-id user-id] (s/join "/" ["/org" org-id "users" user-id]))
 
-(def auth-link (hateoas/link-map "authenticate"
+(def bot-auth-link (hateoas/link-map "bot"
                                  hateoas/GET
                                  (slack-auth-url "bot,users:read")
                                  "text/plain"))
 
-(def auth-retry-link (hateoas/link-map "authenticate-retry"
+(def auth-link (hateoas/link-map "authenticate"
                                  hateoas/GET
                                  (slack-auth-url "identity.basic,identity.email,identity.avatar,identity.team")
                                  "text/plain"))
@@ -69,10 +69,11 @@
                                                (s/join "/" ["/org" org-id "channels"])
                                                "application/vnd.collection+vnd.open-company.slack-channels+json;version=1"))
 
-(def auth-settings {:links [auth-link auth-retry-link]})
+(def auth-settings {:links [auth-link]})
 
 (defn authed-settings [org-id user-id] {:links [(self-link org-id user-id)
                                                 refresh-link
+                                                bot-auth-link
                                                 (invite-link org-id)
                                                 (user-enumerate-link org-id)
                                                 (channel-enumerate-link org-id)]})


### PR DESCRIPTION
___
#### NB: review with this https://github.com/open-company/open-company-web/pull/225
___

Update the Slack authentication and bot onboarding flow.
Now the / endpoint provide only the link to authenticate w/ basic user info. Only when the user is signed in the Slack bot onboard link is sent.