### PR TITLE
Base ML UI

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
     [buddy/buddy-auth "1.4.1"] ; Authentication for ring https://github.com/funcool/buddy-auth
     [zprint "0.4.1"] ; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     
-    [open-company/lib "0.11.7"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [open-company/lib "0.11.8"] ; Library for OC projects https://github.com/open-company/open-company-lib
     ; In addition to common functions, brings in the following common dependencies used by this project:
     ; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
     [buddy/buddy-auth "1.4.1"] ; Authentication for ring https://github.com/funcool/buddy-auth
     [zprint "0.4.1"] ; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     
-    [open-company/lib "0.11.11"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [open-company/lib "0.11.10"] ; Library for OC projects https://github.com/open-company/open-company-lib
     ; In addition to common functions, brings in the following common dependencies used by this project:
     ; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
     [buddy/buddy-auth "1.4.1"] ; Authentication for ring https://github.com/funcool/buddy-auth
     [zprint "0.4.1"] ; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     
-    [open-company/lib "0.11.8"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [open-company/lib "0.11.11"] ; Library for OC projects https://github.com/open-company/open-company-lib
     ; In addition to common functions, brings in the following common dependencies used by this project:
     ; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/src/oc/auth/api/slack.clj
+++ b/src/oc/auth/api/slack.clj
@@ -295,15 +295,14 @@
   (if-let [slack-user (slack/valid-access-token? slack-token)]
     (do
       (timbre/info "Refreshing Slack user" slack-id)
-      (let [updated-user (update-user conn slack-user (dissoc user :admin))]
-        ;; Respond w/ JWToken and location
-        (user-rep/auth-response (-> updated-user
-                                  (clean-user)
-                                  (assoc :admin (:admin user))
-                                  (assoc :slack-id slack-id)
-                                  (assoc :slack-token slack-token)
-                                  (assoc :slack-bots (bots-for conn updated-user)))
-          :slack)))
+      ;; Respond w/ JWToken and location
+      (user-rep/auth-response (-> user
+                                (clean-user)
+                                (assoc :admin (:admin user))
+                                (assoc :slack-id slack-id)
+                                (assoc :slack-token slack-token)
+                                (assoc :slack-bots (bots-for conn updated-user)))
+        :slack))
     (do
       (timbre/warn "Invalid access token" slack-token "for user" user-id)
       (api-common/error-response "Could note confirm token." 400))))

--- a/src/oc/auth/api/slack.clj
+++ b/src/oc/auth/api/slack.clj
@@ -301,7 +301,7 @@
                                 (assoc :admin (:admin user))
                                 (assoc :slack-id slack-id)
                                 (assoc :slack-token slack-token)
-                                (assoc :slack-bots (bots-for conn updated-user)))
+                                (assoc :slack-bots (bots-for conn user)))
         :slack))
     (do
       (timbre/warn "Invalid access token" slack-token "for user" user-id)


### PR DESCRIPTION
Main PR: https://github.com/open-company/open-company-web/pull/244

This PR is needed to update the lib version to accept and create the JWT with the new schema. Also this is intended to fix a problem that came out with the `:slack-users` upgrade of the users table and JWT.
Moving the slack users in one key left out the knowledge of which of them was used as the last one to sign up and fetch the user data. This PR restore the `:slack-id` and `:slack-token` in the JWT to be used to refresh the user data.
Also this avoid to refresh the user data on our side when the slack token is refreshed since we may have had some changes on our part and we don't want to override them.

To test:
- sign up with slack
- go to profile page
- change some data (first name and avatar for example)
- force a token refresh (in web you can do it by running `OCWebForceRefreshToken()` in the console)
- does the token refresh request ended well? good
- go back to your profile page
- do you still see the changes you made? good

this ensure that you where able to refresh the slack token but our user data were not overwritten with the slack user data.