### PR TITLE
Fix missing team logo after initial Slack signup.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,8 +15,8 @@
     [org.clojure/clojure "1.9.0-alpha17"] ; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/tools.cli "0.3.5"] ; Command-line parsing https://github.com/clojure/tools.cli
     [http-kit "2.3.0-alpha2"] ; Web client/server http://http-kit.org/
-    [ring/ring-devel "1.6.1"] ; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-core "1.6.1"] ; Web application library https://github.com/ring-clojure/ring
+    [ring/ring-devel "1.6.2"] ; Web application library https://github.com/ring-clojure/ring
+    [ring/ring-core "1.6.2"] ; Web application library https://github.com/ring-clojure/ring
     [jumblerg/ring.middleware.cors "1.0.1"] ; CORS library https://github.com/jumblerg/ring.middleware.cors
     [ring-logger-timbre "0.7.5" :exclusions [com.taoensso/encore]] ; Ring logging https://github.com/nberger/ring-logger-timbre
     [compojure "1.6.0"] ; A concise routing library for Ring/Clojure https://github.com/weavejester/compojure
@@ -26,7 +26,7 @@
     [buddy/buddy-auth "1.4.1"] ; Authentication for ring https://github.com/funcool/buddy-auth
     [zprint "0.4.2"] ; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     
-    [open-company/lib "0.11.14"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [open-company/lib "0.11.15"] ; Library for OC projects https://github.com/open-company/open-company-lib
     ; In addition to common functions, brings in the following common dependencies used by this project:
     ; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/src/oc/auth/api/slack.clj
+++ b/src/oc/auth/api/slack.clj
@@ -129,13 +129,14 @@
         icon (:icon response)
         image-default (:image-default icon)]
     (or logo-url ; return it if we already had it
-        (if image-default nil ; don't return the Slack default
-            (or (:image_230 icon) ; use the highest resolution we have
-                (:image_132 icon)
-                (:image_88 icon)
-                (:image_44 icon)
-                (:image_34 icon)
-                nil))))) ; give up
+      (when-not image-default ; don't return the Slack default
+        (or ; use the highest resolution we have
+          (:image_230 icon)
+          (:image_132 icon)
+          (:image_88 icon)
+          (:image_44 icon)
+          (:image_34 icon)
+          nil))))) ; give up
 
 ;; ----- Slack Request Handling Functions -----
 


### PR DESCRIPTION
https://trello.com/c/a0NCjjAc

Seems after the refactor into 2 step auth we lost picking up the Team logo when a new OC team is created for a new Slack team. Given the particular scopes and sequence, we never actually get the team logo anymore, so this adjusts that by explicitly asking for team info in a separate call.

To test:

0. Without this branch
1. Clean out your local storage and auth DB.
2. Signup as an OC user with the web UI, notice the new OC team/org doesn't have a logo, you just see "OpenCompany" in the navbar
3. With this branch
4. Clean out your local storage and auth DB.
5. Signup as an OC user with the web UI, notice the new OC team/org has a logo in the navbar
6. Review the code
7. Merge
8. Deploy
9. Goto 0

