### PR TITLE
Adjust Slack scopes to get email address.

### DIFF
--- a/src/oc/auth/api/slack.clj
+++ b/src/oc/auth/api/slack.clj
@@ -126,7 +126,6 @@
   "Get the email for the Slack user with users.info if we don't already have it."
   [{slack-token :slack-token email :email slack-user-id :slack-id}]
   (let [response (when-not email (slack-lib/get-user-info slack-token slack-user-id))] ; get users.info if we need it
-    (println "E4:" response)
     (or email ; return it if we already had it
       (:email response))))
 

--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -68,5 +68,6 @@
 
 (defonce slack-client-id (env :open-company-slack-client-id))
 (defonce slack-client-secret (env :open-company-slack-client-secret))
-(defonce slack-user-scope "users:read,team:read,chat:write:user,channels:read,channels:history")
-(defonce slack-bot-scope "bot,chat:write:bot")
+(defonce slack-user-scope "identity.basic,identity.team,identity.avatar,identity.email")
+(defonce slack-comment-scope "users:read,team:read,chat:write:user,channels:read,channels:history")
+(defonce slack-bot-scope (str slack-comment-scope ",bot,chat:write:bot"))


### PR DESCRIPTION
Dependent on: https://github.com/belucid/open-company-infrastructure/pull/42

This PR addresses the fact that `email` was nil with the scopes we were auth'ing for in 1st pass, and we rely on email in auth.

This changes our scopes to us all identity scopes in the 1st pass, and all the functional scopes in the 2nd pass. This doesn't yet do anything fancy to make the bot stuff conditional in the 2nd pass.

To test:

- Wipe out your DBs.
- Auth a brand new Slack user.
- Do you get through the 2 auth passes and all the way into a new org w/ dashboards with no errors?
- Merge
- Play beer pong