### PR TITLE
Digests

### DIFF
--- a/.lein-spell
+++ b/.lein-spell
@@ -1,12 +1,17 @@
 abcd
 albert
+authing
 camus
 chown
+crypto
+decrypted
 efgh
 gmail
 launchctl
 onboard
 onboarding
+orgs
 plist
 rethinkdb
+unverify
 virtualized

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2015-2016 OpenCompany, LLC.
+Copyright © 2015-2018 OpenCompany, LLC.
 
 Mozilla Public License, version 2.0
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Most of the dependencies are internal, meaning [Leiningen](https://github.com/te
 
 * [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) - a Java 8 JRE is needed to run Clojure
 * [Leiningen](https://github.com/technomancy/leiningen) - Clojure's build and dependency management tool
-* [RethinkDB](http://rethinkdb.com/) v2.3.5+ - a multi-modal (document, key/value, relational) open source NoSQL database
+* [RethinkDB](http://rethinkdb.com/) v2.3.6+ - a multi-modal (document, key/value, relational) open source NoSQL database
 
 #### Java
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ Make sure you update the `CHANGE-ME` items in the section of the `project.clj` t
     :open-company-slack-client-secret "CHANGE-ME"
     :aws-access-key-id "CHANGE-ME"
     :aws-secret-access-key "CHANGE-ME"
-    :aws-secrets-bucket "CHANGE-ME"
     :log-level "debug"
   }
 ```

--- a/README.md
+++ b/README.md
@@ -764,8 +764,7 @@ TBD.
 
 Users are stored as documents in the `users` table of the `open_company_auth` RethinkDB database.
 
-In the case of a Slack user, `owner` and `admin` properties have to do with their privilages in the
-Slack organization. An example stored Slack user:
+In the case of a Slack user, `owner` and `admin` properties have to do with their privileges in the Slack organization. An example stored Slack user:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -868,4 +868,4 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 Distributed under the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/).
 
-Copyright © 2015-2017 OpenCompany, LLC
+Copyright © 2015-2018 OpenCompany, LLC

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![MPL License](http://img.shields.io/badge/license-MPL-blue.svg?style=flat)](https://www.mozilla.org/MPL/2.0/)
 [![Build Status](https://travis-ci.org/open-company/open-company-auth.svg)](https://travis-ci.org/open-company/open-company-auth)
-[![Dependency Status](https://www.versioneye.com/user/projects/562129c236d0ab0021000a0e/badge.svg?style=flat)](https://www.versioneye.com/user/projects/562129c236d0ab0021000a0e)
-[![Roadmap on Trello](http://img.shields.io/badge/roadmap-trello-blue.svg?style=flat)](https://trello.com/b/3naVWHgZ/open-company-development)
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![MPL License](http://img.shields.io/badge/license-MPL-blue.svg?style=flat)](https://www.mozilla.org/MPL/2.0/)
 [![Build Status](https://travis-ci.org/open-company/open-company-auth.svg)](https://travis-ci.org/open-company/open-company-auth)
+[![Dependencies Status](https://versions.deps.co/open-company/open-company-auth/status.svg)](https://versions.deps.co/open-company/open-company-auth)
 
 ## Background
 

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0-RC1"]
+    [org.clojure/clojure "1.9.0"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.5"]
     [http-kit "2.3.0-alpha4"] ; Web client/server http://http-kit.org/
@@ -41,7 +41,7 @@
     ;; Authentication for ring https://github.com/funcool/buddy-auth
     [buddy/buddy-auth "2.1.0"]
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
-    [zprint "0.4.4"]
+    [zprint "0.4.5"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/dakrone/clj-http
     [clj-http "3.7.0"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/clojure/data.json
@@ -50,7 +50,7 @@
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
-    [open-company/lib "0.14.7" :exclusions [clj-http org.clojure/data.json]]
+    [open-company/lib "0.14.8" :exclusions [clj-http org.clojure/data.json]]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let
@@ -68,7 +68,7 @@
   ]
 
   :plugins [
-    [lein-ring "0.12.1"]
+    [lein-ring "0.12.2"]
     [lein-environ "1.1.0"] ; Get environment settings from different sources https://github.com/weavejester/environ
   ]
 
@@ -118,7 +118,6 @@
         :open-company-slack-client-secret "CHANGE-ME"
         :aws-access-key-id "CHANGE-ME"
         :aws-secret-access-key "CHANGE-ME"
-        :aws-secrets-bucket "CHANGE-ME"
         :log-level "debug"
       }
       :plugins [
@@ -138,7 +137,7 @@
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: rewrite-cljs not needed
-        [lein-zprint "0.3.5" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
+        [lein-zprint "0.3.6" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
       ]
     }]
 

--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
-    [open-company/lib "0.14.8" :exclusions [clj-http org.clojure/data.json]]
+    [open-company/lib "0.14.13" :exclusions [clj-http org.clojure/data.json]]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let
@@ -68,7 +68,7 @@
   ]
 
   :plugins [
-    [lein-ring "0.12.2"]
+    [lein-ring "0.12.3"]
     [lein-environ "1.1.0"] ; Get environment settings from different sources https://github.com/weavejester/environ
   ]
 

--- a/project.clj
+++ b/project.clj
@@ -129,7 +129,7 @@
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
         [lein-pprint "1.2.0"]
         ;; Check for outdated dependencies https://github.com/xsc/lein-ancient
-        [lein-ancient "0.6.14"]
+        [lein-ancient "0.6.15"]
         ;; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
         [lein-spell "0.1.0"]
         ;; Dead code finder https://github.com/venantius/yagni

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0-beta1"]
+    [org.clojure/clojure "1.9.0-beta3"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.5"]
     [http-kit "2.3.0-alpha4"] ; Web client/server http://http-kit.org/
@@ -29,7 +29,7 @@
     ;; Ring logging https://github.com/nberger/ring-logger-timbre
     ;; NB: com.taoensso/encore pulled in by oc.lib
     ;; NB: com.taoensso/timbre pulled in by oc.lib
-    [ring-logger-timbre "0.7.5" :exclusions [com.taoensso/encore com.taoensso/timbre]] 
+    [ring-logger-timbre "0.7.6" :exclusions [com.taoensso/encore com.taoensso/timbre]] 
     ;; Web routing https://github.com/weavejester/compojure
     [compojure "1.6.0"]
     ;; Clojure Slack REST API https://github.com/julienXX/clj-slack
@@ -41,7 +41,7 @@
     ;; Authentication for ring https://github.com/funcool/buddy-auth
     [buddy/buddy-auth "2.1.0"]
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
-    [zprint "0.4.2"]
+    [zprint "0.4.4"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/dakrone/clj-http
     [clj-http "3.7.0"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/clojure/data.json
@@ -50,7 +50,7 @@
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
-    [open-company/lib "0.14.5" :exclusions [clj-http org.clojure/data.json]]
+    [open-company/lib "0.14.7" :exclusions [clj-http org.clojure/data.json]]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let
@@ -94,7 +94,7 @@
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.4"]
+        [jonase/eastwood "0.2.6-beta2"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: org.clojure/tools.reader pulled in manually
@@ -124,13 +124,13 @@
       :plugins [
         ;; Check for code smells https://github.com/dakrone/lein-bikeshed
         ;; NB: org.clojure/tools.cli is pulled in by lein-kibit
-        [lein-bikeshed "0.4.1" :exclusions [org.clojure/tools.cli]] 
+        [lein-bikeshed "0.5.0" :exclusions [org.clojure/tools.cli]] 
         ;; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-checkall "0.1.1"]
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
         [lein-pprint "1.1.2"]
         ;; Check for outdated dependencies https://github.com/xsc/lein-ancient
-        [lein-ancient "0.6.12"]
+        [lein-ancient "0.6.14"]
         ;; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
         [lein-spell "0.1.0"]
         ;; Dead code finder https://github.com/venantius/yagni
@@ -138,7 +138,7 @@
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: rewrite-cljs not needed
-        [lein-zprint "0.3.2" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
+        [lein-zprint "0.3.4" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
       ]
     }]
 

--- a/project.clj
+++ b/project.clj
@@ -13,17 +13,17 @@
 
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0-beta3"]
+    [org.clojure/clojure "1.9.0-RC1"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.5"]
     [http-kit "2.3.0-alpha4"] ; Web client/server http://http-kit.org/
     ;; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-devel "1.6.2"]
+    [ring/ring-devel "1.6.3"]
     ;; Web application library https://github.com/ring-clojure/ring
     ;; NB: clj-time pulled in by oc.lib
     ;; NB: joda-time pulled in by oc.lib via clj-time
     ;; NB: commons-codec pulled in by oc.lib
-    [ring/ring-core "1.6.2" :exclusions [clj-time joda-time commons-codec]]
+    [ring/ring-core "1.6.3" :exclusions [clj-time joda-time commons-codec]]
     ;; CORS library https://github.com/jumblerg/ring.middleware.cors
     [jumblerg/ring.middleware.cors "1.0.1"]
     ;; Ring logging https://github.com/nberger/ring-logger-timbre
@@ -86,7 +86,7 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.0-alpha10" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.0" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
         ;; Test Ring requests https://github.com/weavejester/ring-mock
         [ring-mock "0.1.5"]
       ]
@@ -98,12 +98,12 @@
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: org.clojure/tools.reader pulled in manually
-        [lein-kibit "0.1.6-beta2" :exclusions [org.clojure/clojure rewrite-clj org.clojure/tools.reader]]
+        [lein-kibit "0.1.6" :exclusions [org.clojure/clojure rewrite-clj org.clojure/tools.reader]]
         ;; Dependency of lein-kibit and lein-zprint https://github.com/xsc/rewrite-clj
         ;; NB: org.clojure/tools.reader pulled in manually
         [rewrite-clj "0.6.0" :exclusions [org.clojure/tools.reader]]
         ;; Not used directly, dependency of lein-kibit and rewrite-clj https://github.com/clojure/tools.reader
-        [org.clojure/tools.reader "1.1.0"]
+        [org.clojure/tools.reader "1.1.1"]
       ]
     }
 
@@ -128,7 +128,7 @@
         ;; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-checkall "0.1.1"]
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
-        [lein-pprint "1.1.2"]
+        [lein-pprint "1.2.0"]
         ;; Check for outdated dependencies https://github.com/xsc/lein-ancient
         [lein-ancient "0.6.14"]
         ;; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
@@ -138,7 +138,7 @@
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: rewrite-cljs not needed
-        [lein-zprint "0.3.4" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
+        [lein-zprint "0.3.5" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
       ]
     }]
 

--- a/project.clj
+++ b/project.clj
@@ -82,11 +82,10 @@
       }
       :dependencies [
         ;; Example-based testing https://github.com/marick/Midje
-        ;; NB: org.clojure/tools.macro is pulled in manually
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.0" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.2-alpha2" :exclusions [joda-time clj-time commons-codec]] 
         ;; Test Ring requests https://github.com/weavejester/ring-mock
         [ring-mock "0.1.5"]
       ]

--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
-    [open-company/lib "0.14.13" :exclusions [clj-http org.clojure/data.json]]
+    [open-company/lib "0.14.14" :exclusions [clj-http org.clojure/data.json]]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/src/dev.clj
+++ b/src/dev.clj
@@ -26,8 +26,7 @@
 
 (defn go
 
-  ([]
-  (go c/auth-server-port))
+  ([] (go c/auth-server-port))
   
   ([port]
   (init port)

--- a/src/oc/auth/api/slack.clj
+++ b/src/oc/auth/api/slack.clj
@@ -119,7 +119,7 @@
   "Create a new user for the specified Slack user."
   [conn new-user teams]
   (timbre/info "Creating new user:" (:email new-user) (:first-name new-user) (:last-name new-user))
-  (user-res/create-user! conn (-> (user-res/->user new-user)
+  (user-res/create-user! conn (-> new-user
                                 (assoc :status :active)
                                 (assoc :teams (map :team-id teams)))))
 

--- a/src/oc/auth/api/slack.clj
+++ b/src/oc/auth/api/slack.clj
@@ -119,7 +119,7 @@
   "Create a new user for the specified Slack user."
   [conn new-user teams]
   (timbre/info "Creating new user:" (:email new-user) (:first-name new-user) (:last-name new-user))
-  (user-res/create-user! conn (-> new-user
+  (user-res/create-user! conn (-> (user-res/->user new-user)
                                 (assoc :status :active)
                                 (assoc :teams (map :team-id teams)))))
 

--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -168,7 +168,7 @@
                           (user-rep/auth-response conn
                             (-> user
                               (assoc :admin admin-teams)
-                              (assoc :slack-bots (slack-api/bots-for conn user)))
+                              (assoc :slack-bots (jwt/bots-for conn user)))
                             :email)))))
 
 ;; A resource for creating users by email
@@ -211,7 +211,7 @@
                                 (api-common/blank-response)
                                 ;; respond w/ JWToken and location
                                 (user-rep/auth-response conn
-                                  (assoc user :slack-bots (slack-api/bots-for conn user))
+                                  (assoc user :slack-bots (jwt/bots-for conn user))
                                   :email)))))
 
 
@@ -293,7 +293,7 @@
                         ;; Email token - respond w/ JWToken and location
                         "email" (let [user (:existing-user ctx)]
                                   (user-rep/auth-response conn
-                                    (assoc user :slack-bots (slack-api/bots-for conn user))
+                                    (assoc user :slack-bots (jwt/bots-for conn user))
                                     :email))
 
                         ;; Slack token - defer to Slack API handler

--- a/src/oc/auth/db/migrations/1513349361282_add_digest_props.edn
+++ b/src/oc/auth/db/migrations/1513349361282_add_digest_props.edn
@@ -1,0 +1,20 @@
+(ns oc.auth.db.migrations.add-digest-props
+  (:require [rethinkdb.query :as r]
+            [oc.lib.db.migrations :as m]
+            [oc.lib.db.common :as db-common]
+            [oc.auth.config :as config]
+            [oc.auth.resources.user :as user-res]))
+
+(defn up [conn]
+
+  (println "Add new properties to existing users...")
+  (let [users (db-common/read-resources conn user-res/table-name)]
+    (println "Updating" (count users) "existing users...")
+    (doseq [user users]
+      (-> (r/table user-res/table-name)
+        (r/get (user-res/primary-key user))
+        (r/update (r/fn [resource]
+          {:digest-frequency :daily
+           :digest-medium :email}))
+        (r/run conn))))
+  true) ; return true on success

--- a/src/oc/auth/db/migrations/1513349361283_add_digest_props.edn
+++ b/src/oc/auth/db/migrations/1513349361283_add_digest_props.edn
@@ -17,4 +17,7 @@
           {:digest-frequency :daily
            :digest-medium :email}))
         (r/run conn))))
+
+  (println (m/create-index conn user-res/table-name "digest-frequency"))
+
   true) ; return true on success

--- a/src/oc/auth/representations/user.clj
+++ b/src/oc/auth/representations/user.clj
@@ -79,13 +79,6 @@
       (delete-link user-id)
       teams-link])))
 
-(defun- name-for 
-  ([user] (name-for (:first-name user) (:last-name user)))
-  ([first-name :guard s/blank? last-name :guard s/blank?] "")
-  ([first-name last-name :guard s/blank?] first-name)
-  ([first-name :guard s/blank? last-name] last-name)
-  ([first-name last-name] (str first-name " " last-name)))
-
 (schema/defn ^:always-validate jwt-props-for
   [user :- user-res/UserRep source :- schema/Keyword]
   (let [jwt-props (zipmap jwt-props (map user jwt-props))
@@ -104,7 +97,7 @@
                             (assoc bot-props :slack-users (:slack-users user))
                             bot-props)]
     (-> slack-users-props
-      (assoc :name (name-for user))
+      (assoc :name (jwt/name-for user))
       (assoc :auth-source source)
       (assoc :refresh-url (str config/auth-server-url "/users/refresh")))))
 

--- a/src/oc/auth/representations/user.clj
+++ b/src/oc/auth/representations/user.clj
@@ -16,7 +16,9 @@
             [oc.auth.resources.user :as user-res]))
 
 (def slack-props [:name :slack-id :slack-org-id])
-(def oc-props [:user-id :first-name :last-name :email :avatar-url :created-at :updated-at :slack-users])
+(def oc-props [:user-id :first-name :last-name :email :avatar-url
+               :digest-frequency :digest-medium :timezone
+               :created-at :updated-at :slack-users])
 (def representation-props (concat slack-props oc-props))
 (def jwt-props [:user-id :first-name :last-name :name :email :avatar-url :teams :admin])
 
@@ -116,8 +118,7 @@
 (schema/defn ^:always-validate render-user-for-collection
   "Create a map of the user for use in a collection in the REST API"
   [team-id :- lib-schema/UniqueID user]
-  {:pre [(map? user)
-         (schema/validate user-res/User (dissoc user :admin?))]}
+  {:pre [(map? user)]}
   (let [user-id (:user-id user)]
     (-> user
       (select-keys (concat representation-props [:admin? :status]))

--- a/src/oc/auth/resources/team.clj
+++ b/src/oc/auth/resources/team.clj
@@ -112,7 +112,6 @@
   "Given the team-id of the team, delete it and return `true` on success."
   [conn team-id :- lib-schema/UniqueID]
   {:pre [(db-common/conn? conn)]}
-  ;; TODO remove team from users
   (try
     (db-common/delete-resource conn table-name team-id)
     (catch java.lang.RuntimeException e))) ; it's OK if there is no team to delete

--- a/src/oc/auth/resources/user.clj
+++ b/src/oc/auth/resources/user.clj
@@ -45,7 +45,7 @@
           :last-name schema/Str
           :avatar-url (schema/maybe schema/Str)
 
-          (schema/optional-key :time-zone) schema/Str ; want it missing at first so we can default it on the client
+          (schema/optional-key :timezone) schema/Str ; want it missing at first so we can default it on the client
 
           :digest-medium (schema/pred #(digest-medium (keyword %)))
           :digest-frequency (schema/pred #(digest-frequency (keyword %)))

--- a/src/oc/auth/resources/user.clj
+++ b/src/oc/auth/resources/user.clj
@@ -28,6 +28,10 @@
   "
   #{:pending :unverified :active})
 
+(def digest-medium #{:email :slack})
+
+(def digest-frequency #{:daily :weekly :never})
+
 (def ^:private UserCommon
   (merge {:user-id lib-schema/UniqueID
           :teams [lib-schema/UniqueID]
@@ -40,6 +44,12 @@
           :first-name schema/Str
           :last-name schema/Str
           :avatar-url (schema/maybe schema/Str)
+
+          (schema/optional-key :time-zone) schema/Str ; want it missing at first so we can default it on the client
+
+          :digest-medium (schema/pred #(digest-medium (keyword %)))
+          :digest-frequency (schema/pred #(digest-frequency (keyword %)))
+
           (schema/optional-key :last-token-at) lib-schema/ISO8601}
          lib-schema/slack-users))
 
@@ -139,6 +149,8 @@
         (update :first-name #(or % ""))
         (update :last-name #(or % ""))
         (update :avatar-url #(or % ""))
+        (update :digest-frequency #(or % :daily))
+        (update :digest-medium #(or % :email)) ; lowest common denominator
         (assoc :status :pending)
         (assoc :created-at ts)
         (assoc :updated-at ts)))))


### PR DESCRIPTION
Supports: https://trello.com/c/YBUH0SR6

Involved with the following lib change: https://github.com/open-company/open-company-lib/pull/22

Supports this web UI change: https://github.com/open-company/open-company-web/pull/326 

This PR adds `digest-frequency` and `digest-medium` to the Auth user model, with an index on the former. It has a migration so all existing users get `daily` and `email` respectively.

Otherwise it has a few fns related to building up a JWToken factored out into oc.lib for sharing with the Digest service.

- [x] Review the code
- [x] Start your auth service to run the migration, or run it with lein
- [x] Use the `digest` web branch and update your digest frequency, medium and timezone. All seem OK with the updates?
- [x] Do a little bit of regression testing on web mainline, logging out and in with a Slack and an email user
- [x] This PR does no harm to existing use of Auth, so can role out to staging and beta on its own, so deploy!
- [ ] Learn to play the mandolin