### PR TITLE
Move bad email domain response from 422 to 409 to avoid a Sentry.

### DIFF
--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -402,6 +402,7 @@
   
   ;; Responses
   :respond-with-entity? false
+  :handle-unprocessable-entity (fn [ctx] (api-common/text-response "Email domain not allowed." 409))
   :handle-created (fn [ctx] (if (or (:updated-team ctx) (:existing-domain ctx))
                               (api-common/blank-response)
                               (api-common/missing-response)))


### PR DESCRIPTION
https://trello.com/c/BpksIEX4

Just what it says on the tin, no Sentry when we error the email domain by using a 409.

Retest by using web UI to try a blacklisted email domain on a server that reports to Sentry.