### PR TITLE
Private invite notification

### DIFF
--- a/REPL_notes.clj
+++ b/REPL_notes.clj
@@ -35,5 +35,5 @@
 (with-open [c (apply r/connect conn2)]
   (-> (r/table "users")
     (r/get-all ["30b6-4fdd-b4fa" "8c3b-462a-b8e6" "4c61-4782-b0b3" "be62-4263-8b72"])
-    (r/update (r/fn [_] {:status "verified"}))
+    (r/update (r/fn [_] {:status "active"}))
     (r/run c)))

--- a/REPL_notes.clj
+++ b/REPL_notes.clj
@@ -30,3 +30,10 @@
       (r/get "f725-4791-80ac")
       (r/update {:name "GreenLabs"})
       (r/run c)))
+
+;; Update a set of users
+(with-open [c (apply r/connect conn2)]
+  (-> (r/table "users")
+    (r/get-all ["30b6-4fdd-b4fa" "8c3b-462a-b8e6" "4c61-4782-b0b3" "be62-4263-8b72"])
+    (r/update (r/fn [_] {:status "verified"}))
+    (r/run c)))

--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
     ;; Authentication for ring https://github.com/funcool/buddy-auth
     [buddy/buddy-auth "2.1.0"]
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
-    [zprint "0.4.6"]
+    [zprint "0.4.7"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/dakrone/clj-http
     [clj-http "3.7.0"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/clojure/data.json
@@ -136,7 +136,7 @@
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: rewrite-cljs not needed
-        [lein-zprint "0.3.7" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
+        [lein-zprint "0.3.8" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
       ]
     }]
 

--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -465,7 +465,7 @@
           slack-orgs (slack-org-res/list-slack-orgs-by-ids conn (:slack-orgs team) [:bot-token]) ; Slack orgs for team
           bot-tokens (map :bot-token (filter :bot-token slack-orgs)) ; Bot tokens of Slack orgs w/ a bot
           slack-users (mapcat #(slack/user-list %) bot-tokens) ; Slack roster of users
-          oc-users (user-res/list-users conn team-id [:status :created-at :updated-at]) ; OC roster of users
+          oc-users (user-res/list-users conn team-id [:status :created-at :updated-at :slack-users]) ; OC roster of users
           slack-emails (set (map :email slack-users)) ; email of Slack users
           oc-emails (set (map :email oc-users)) ; email of OC users
           uninvited-slack-emails (clojure.set/difference slack-emails oc-emails) ; email of Slack users that aren't OC


### PR DESCRIPTION
What follows is a set of PRs needed for the private board notification feature found at https://trello.com/c/bMNmtW1x/1157-private-board-invite-notification

The general idea is to have the web client receive all needed information to send a slack or email message to a user.  When a user adds another user to a private board the added user information is sent along with the API request to update or create the board. The storage service will then extract that information and send it over SNS.  The bot and email service will listen on SNS and notify a user using the information when they see the private board access change.

This approach seemed best instead of having to make another API request to the bot or email service.

This change returns more slack information in the team roster request.

You will need the following PR branches to test:
Web -  https://github.com/open-company/open-company-web/pull/373
Storage - https://github.com/open-company/open-company-storage/pull/110

- [x] Make sure auth and storage are running the correct branches `private-invite-notification`.
- [x] Make sure web is using the branch `private-board-notifications`.
- [x] You will need a slack user and an additional team member as admin.
- [x] As the admin create a new private board.  Add the slack user to the list of board users.
- [x] When creating the board you should see the storage service send a list of notifications over SNS. To verify this , the easiest way is to run the `private-invite-notification` branch in the bot service. The slack user will see a message from Carrot saying they were invited to a private board. https://github.com/open-company/open-company-bot/tree/private-invite-notification

- [ ] merge the web, auth, and storage branch.
- [ ] deploy all three
