### PR TITLE
Fix the activate of a user on Slack auth (was there, but broken).

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
     [org.clojure/clojure "1.9.0"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.5"]
-    [http-kit "2.3.0-alpha5"] ; Web client/server http://http-kit.org/
+    [http-kit "2.3.0-beta1"] ; Web client/server http://http-kit.org/
     ;; Web application library https://github.com/ring-clojure/ring
     [ring/ring-devel "1.6.3"]
     ;; Web application library https://github.com/ring-clojure/ring
@@ -35,7 +35,7 @@
     ;; Clojure Slack REST API https://github.com/julienXX/clj-slack
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
-    [org.julienxx/clj-slack "0.5.5" :exclusions [clj-http org.clojure/data.json]]
+    [org.julienxx/clj-slack "0.5.6" :exclusions [clj-http org.clojure/data.json]]
     ;; Security library https://github.com/funcool/buddy
     [buddy "2.0.0"]
     ;; Authentication for ring https://github.com/funcool/buddy-auth
@@ -43,7 +43,7 @@
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     [zprint "0.4.7"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/dakrone/clj-http
-    [clj-http "3.7.0"]
+    [clj-http "3.8.0"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/clojure/data.json
     [org.clojure/data.json "0.2.6"]
     
@@ -85,7 +85,7 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.2-alpha2" :exclusions [joda-time clj-time commons-codec]] 
+        [midje "1.9.2-alpha3" :exclusions [joda-time clj-time commons-codec]] 
         ;; Test Ring requests https://github.com/weavejester/ring-mock
         [ring-mock "0.1.5"]
       ]
@@ -102,7 +102,7 @@
         ;; NB: org.clojure/tools.reader pulled in manually
         [rewrite-clj "0.6.0" :exclusions [org.clojure/tools.reader]]
         ;; Not used directly, dependency of lein-kibit and rewrite-clj https://github.com/clojure/tools.reader
-        [org.clojure/tools.reader "1.2.2"]
+        [org.clojure/tools.reader "1.3.0-alpha3"]
       ]
     }
 

--- a/src/oc/auth/api/slack.clj
+++ b/src/oc/auth/api/slack.clj
@@ -236,12 +236,11 @@
                                                                   :slack-org-id (:slack-org-id slack-user)
                                                                   :token (:slack-token slack-user)}}
 
-            ;; Add or update the Slack users list of the user
-            updated-slack-user (user-res/update-user! conn
-                                                      (:user-id user)
-                                                      (-> user
-                                                        (assoc :status :active) ; no longer :pending (if they were)
-                                                        (update-in [:slack-users] merge new-slack-user)))
+            ;; Activate the user (Slack is a trusted email verifier) and upsert the Slack users to the list for the user
+            updated-slack-user (do (user-res/activate! conn (:user-id user)) ; no longer :pending (if they were)
+                                   (user-res/update-user! conn
+                                                          (:user-id user)
+                                                          (update-in user [:slack-users] merge new-slack-user)))
             
             ;; Create a JWToken from the user for the response
             jwt-user (user-rep/jwt-props-for (-> updated-slack-user


### PR DESCRIPTION
https://trello.com/c/xdAUlUJx

"1-liner" fix of broken activation of Slack user. To test:

- [x] Register as a new email user with an email that matches a Slack user you have access to
- [x] NOTE: Don't validate the user's email with the email verification email
- [x] Notice in auth DB/Repl your status is not `active`
- [x] Logout
- [x] Log back in, this time with Slack
- [x] Notice in auth DB/Repl your status is now `active`
- [x] Merge
- [x] Deploy
- [ ] Dance the hava nagila
