### PR TITLE
Always ask for the permission to write comment as user. 

### DIFF
--- a/src/oc/auth/api/slack.clj
+++ b/src/oc/auth/api/slack.clj
@@ -250,16 +250,16 @@
                                                 (assoc :slack-token (:slack-token slack-user))) :slack)
 
             ;; Determine where we redirect them to
-            bot-only? (and target-team ((set (:slack-orgs target-team)) (:slack-org-id slack-org)))
-            redirect-arg (if bot-only? :bot :team)]
+            bot-only? (and target-team ((set (:slack-orgs target-team)) (:slack-org-id slack-org)))]
         ;; Add the Slack org to the existing team if needed
         (when (and target-team (not bot-only?))
           (team-res/add-slack-org conn team-id (:slack-org-id slack-org)))
-
         (let [bot-team-id (if new-team (:team-id new-team) (:team-id (first relevant-teams)))
-              bot-user-id (if new-user (:user-id new-user) (:user-id existing-user))]
-          (response/redirect (:href (slack-rep/bot-link (str bot-team-id ":" bot-user-id ":" redirect ":" (:slack-org-id slack-org)))))))
-
+              bot-user-id (if new-user (:user-id new-user) (:user-id existing-user))
+              redirect-url (if (and (not bot-only?) slack-org (not (contains? slack-org :bot-token)))
+                             (:href (slack-rep/bot-link (str bot-team-id ":" bot-user-id ":" redirect ":" (:slack-org-id slack-org))))
+                             (:href (slack-rep/comment-link (str bot-team-id ":" bot-user-id ":" redirect ":" (:slack-org-id slack-org)))))]
+          (response/redirect redirect-url)))
       ;; Error came back from Slack, send them back to the OC Web UI
       (redirect-to-web-ui redirect :failed)))
 

--- a/src/oc/auth/api/slack.clj
+++ b/src/oc/auth/api/slack.clj
@@ -255,16 +255,10 @@
         ;; Add the Slack org to the existing team if needed
         (when (and target-team (not bot-only?))
           (team-res/add-slack-org conn team-id (:slack-org-id slack-org)))
-        ;; When we are authing a user for a Slack team w/o the bot installed, we redirect to the 
-        ;; bot access directly
-        (if (and (not bot-only?) slack-org (not (contains? slack-org :bot-token)))
-          (let [bot-team-id (if new-team (:team-id new-team) (:team-id (first relevant-teams)))
-                bot-user-id (if new-user (:user-id new-user) (:user-id existing-user))]
-            (response/redirect (:href (slack-rep/bot-link (str bot-team-id ":" bot-user-id ":" redirect ":" (:slack-org-id slack-org))))))
-          ;; All done, send them back to the OC Web UI with a JWToken
-          (redirect-to-web-ui redirect redirect-arg
-            (jwtoken/generate conn (assoc jwt-user :slack-bots (lib-jwt/bots-for conn jwt-user)))
-            (:last-token-at user))))
+
+        (let [bot-team-id (if new-team (:team-id new-team) (:team-id (first relevant-teams)))
+              bot-user-id (if new-user (:user-id new-user) (:user-id existing-user))]
+          (response/redirect (:href (slack-rep/bot-link (str bot-team-id ":" bot-user-id ":" redirect ":" (:slack-org-id slack-org)))))))
 
       ;; Error came back from Slack, send them back to the OC Web UI
       (redirect-to-web-ui redirect :failed)))

--- a/src/oc/auth/representations/slack_auth.clj
+++ b/src/oc/auth/representations/slack_auth.clj
@@ -33,6 +33,10 @@
     {:auth-source "slack"
     :authentication "oauth"}))
 
+(defn comment-link
+  ([] (comment-link nil))
+  ([state] (slack-link "bot" config/slack-comment-scope state)))
+
 (defn bot-link 
   ([] (bot-link nil))
   ([state] (slack-link "bot" config/slack-bot-scope state)))


### PR DESCRIPTION
Bot permission is asked for only if bot is not part of the team.


To test:
First see the SLACK_TESTING document in infrastructure to get slack account info.

- Login as owner of slack workspace and authorize the carrot bot.
- Login to slack as a non owner
- Invite the non owner to carrot as an admin.
- [x] Does the carrot app notify you that you have an invite?

- Signup with the invited user.
- Create a section that posts to slack .
- Create a post in that section
- [ ] Does it show the post from the carrot app in the slack channel?
- Comment on the post
- [ ] Does it show the comment as the correct slack user?