### PR TITLE
Need additional scope for slack to read urls.

### DIFF
--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -69,8 +69,12 @@
 (defonce slack-client-id (env :open-company-slack-client-id))
 (defonce slack-client-secret (env :open-company-slack-client-secret))
 (defonce slack-user-scope "identity.basic,identity.team,identity.avatar,identity.email")
+(defonce slack-unfurl-scope "links:read,links:write")
 (defonce slack-comment-scope "users:read,users:read.email,team:read,chat:write:user,channels:read,channels:history")
-(defonce slack-bot-scope (str slack-comment-scope ",bot,chat:write:bot"))
+(defonce slack-bot-scope (str slack-comment-scope
+                              ","
+                              slack-unfurl-scope
+                              ",bot,chat:write:bot"))
 
 ;; ----- Email -----
 


### PR DESCRIPTION
Asks for more permissions so we can unfurl urls in slack.

https://api.slack.com/docs/message-link-unfurling

When logging into slack you will see a new scope message starting with 'View links...'.