### PR TITLE
Add missing keys for the slack invite.

### DIFF
--- a/src/oc/auth/lib/sqs.clj
+++ b/src/oc/auth/lib/sqs.clj
@@ -64,6 +64,9 @@
     :first-name schema/Str ; invitee's first name
     :org-name schema/Str
     :url lib-schema/NonBlankStr
+    :org-logo-url schema/Str
+    :org-logo-width schema/Int
+    :org-logo-height schema/Int
   }))
 
 ;; ----- SQS Message Creation -----


### PR DESCRIPTION
While reviewing `always-bot` i found that the current invite to slack is broken, this fixes it.

To test:
- signup with a new slack org on carrot
- invite someone via Slack to carrot
- [x] check the network request is NOT a 422? Good
- [x] did it go through? Good
- login into slack with the invited user
- [x] do you see the invite? Good

