### PR TITLE
Delay verify email

### DIFF
--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -100,7 +100,8 @@
       (timbre/info "Sending email verification request for:" user-id "(" email ")")
       (sqs/send! sqs/TokenAuth
                  (sqs/->token-auth {:type :verify :email email :token (:one-time-token created-user)})
-                 config/aws-sqs-email-queue)
+                 config/aws-sqs-email-queue
+                 (if (= (keyword (:status created-user)) :pending) 0 900))
       (timbre/info "Sent email verification for:" user-id "(" email ")")
       {:new-user (assoc created-user :admin admin-teams)})
     

--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -101,7 +101,7 @@
       (sqs/send! sqs/TokenAuth
                  (sqs/->token-auth {:type :verify :email email :token (:one-time-token created-user)})
                  config/aws-sqs-email-queue
-                 (if (= (keyword (:status created-user)) :pending) 0 900))
+                 (if (= (keyword (:status created-user)) :unverified) 900 0))
       (timbre/info "Sent email verification for:" user-id "(" email ")")
       {:new-user (assoc created-user :admin admin-teams)})
     

--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -101,7 +101,7 @@
       (sqs/send! sqs/TokenAuth
                  (sqs/->token-auth {:type :verify :email email :token (:one-time-token created-user)})
                  config/aws-sqs-email-queue
-                 (if (= (keyword (:status created-user)) :unverified) 900 0))
+                 (if (not= (keyword (:status created-user)) :pending) 900 0))
       (timbre/info "Sent email verification for:" user-id "(" email ")")
       {:new-user (assoc created-user :admin admin-teams)})
     

--- a/src/oc/auth/lib/sqs.clj
+++ b/src/oc/auth/lib/sqs.clj
@@ -132,7 +132,8 @@
 ;; ----- SQS Message Functions -----
 
 (defn send!
-  [msg-schema msg sqs-queue]
+  ([msg-schema msg sqs-queue] (send! msg-schema msg sqs-queue 0))
+  ([msg-schema msg sqs-queue seconds-delay]
   (let [type (or (:type msg) (-> msg :script :id))
         to (or (:to msg) (-> msg :receiver :id))]
     (timbre/info "Request to send" type "to:" to)
@@ -141,6 +142,7 @@
     (sqs/send-message
       {:access-key config/aws-access-key-id
        :secret-key config/aws-secret-access-key}
-      sqs-queue
-      msg)
-    (timbre/info "Sent" type "to:" to)))
+      :queue-url sqs-queue
+      :message-body msg
+      :delay-seconds seconds-delay)
+    (timbre/info "Sent" type "to:" to "with delay" seconds-delay))))


### PR DESCRIPTION
Card: https://trello.com/c/03J3fBFh

Delay the verification email only for those users that creates a team, no delay for all the other users and type of emails.

To test:
- signup
- after entering the email and password check auth log
- [x] do you see `Sent verify to: your@email.here`? Good
- [x] does it have 900 as delay? Good
- now finish signup
- invite someone
- check auth logs
- [x] do you see the `Sent verify to: invited@email.here`? Good
- [x] does it has 0 delay? Good
- test also with Slack org if you want: first user has 900 seconds, all the other 0
- [x] did you receive the first user verification email? Good
