### PR TITLE
De-dupe teams coming from Slack and email matches.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,8 +15,8 @@
     ;; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/clojure "1.9.0"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
-    [org.clojure/tools.cli "0.3.5"]
-    [http-kit "2.3.0-beta2"] ; Web client/server http://http-kit.org/
+    [org.clojure/tools.cli "0.3.7"]
+    [http-kit "2.3.0"] ; Web client/server http://http-kit.org/
     ;; Web application library https://github.com/ring-clojure/ring
     [ring/ring-devel "1.6.3"]
     ;; Web application library https://github.com/ring-clojure/ring
@@ -31,7 +31,7 @@
     ;; NB: com.taoensso/timbre pulled in by oc.lib
     [ring-logger-timbre "0.7.6" :exclusions [com.taoensso/encore com.taoensso/timbre]] 
     ;; Web routing https://github.com/weavejester/compojure
-    [compojure "1.6.0"]
+    [compojure "1.6.1"]
     ;; Clojure Slack REST API https://github.com/julienXX/clj-slack
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
@@ -43,14 +43,14 @@
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     [zprint "0.4.7"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/dakrone/clj-http
-    [clj-http "3.8.0"]
+    [clj-http "3.9.0"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/clojure/data.json
     [org.clojure/data.json "0.2.6"]
     
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
-    [open-company/lib "0.16.3" :exclusions [clj-http org.clojure/data.json]]
+    [open-company/lib "0.16.4" :exclusions [clj-http org.clojure/data.json]]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/src/oc/auth/resources/user.clj
+++ b/src/oc/auth/resources/user.clj
@@ -162,7 +162,7 @@
   (let [email (:email user)
         email-domain (last (s/split email #"\@"))
         email-teams (map :team-id (team-res/list-teams-by-index conn :email-domains email-domain))
-        existing-teams (concat email-teams (:teams user))
+        existing-teams (vec (set (concat email-teams (:teams user))))
         new-team (when (empty? existing-teams)
                     (team-res/create-team! conn (team-res/->team {} (:user-id user))))
         teams (if new-team [(:team-id new-team)] existing-teams)


### PR DESCRIPTION
https://trello.com/c/oDBBX5qq

This fixes seeing duplicate users in the UI because the user has the same team duplicated in their `:teams` sequence.

To replicate:

Without this branch, create a org with Slack, add the email domain of another member of the Slack team. Then invite the member with Slack. The code will try to pull in matching teams via Slack and also via email domain and end up pulling the same team twice into the new users `:teams` property.

To test:

- [x] Switch to this branch
- [x] Repeat the test steps above
- [x] Look at the user in the REPL, is their only 1 ID in the `:teams` sequence? It's not duplicated twice?
- [x] Merge
- [x] Deploy
- [x] Drink 12-16 cups of H20 today for proper health and hydration