### PR TITLE
Handle the app removal event from Slack.

### DIFF
--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -435,7 +435,7 @@
 
   ;; Actions
   :delete! (fn [ctx]
-             (when (:has-org? ctx)               
+             (when (:has-org? ctx)
                (team-res/remove-slack-org conn team-id slack-org-id)
                (slack-org-res/delete-slack-org! conn slack-org-id)))
 

--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -434,7 +434,10 @@
                         false))
 
   ;; Actions
-  :delete! (fn [ctx] (when (:has-org? ctx) (team-res/remove-slack-org conn team-id slack-org-id)))
+  :delete! (fn [ctx]
+             (when (:has-org? ctx)               
+               (team-res/remove-slack-org conn team-id slack-org-id)
+               (slack-org-res/delete-slack-org! conn slack-org-id)))
 
   ;; Responses
   :respond-with-entity? false

--- a/src/oc/auth/app.clj
+++ b/src/oc/auth/app.clj
@@ -22,7 +22,8 @@
     [oc.auth.api.entry-point :as entry-point-api]
     [oc.auth.api.slack :as slack-api]
     [oc.auth.api.users :as users-api]
-    [oc.auth.api.teams :as teams-api]))
+    [oc.auth.api.teams :as teams-api]
+    [oc.auth.async.slack-router :as slack-router]))
 
 ;; ----- Unhandled Exceptions -----
 
@@ -57,6 +58,7 @@
     "Database: " c/db-name "\n"
     "Database pool: " c/db-pool-size "\n"
     "AWS SQS email queue: " c/aws-sqs-email-queue "\n"
+    "AWS SQS email queue: " c/aws-sqs-slack-router-auth-queue "\n"
     "Trace: " c/liberator-trace "\n"
     "Hot-reload: " c/hot-reload "\n"
     "Sentry: " c/dsn "\n\n"
@@ -88,6 +90,10 @@
 
   ;; Start the system
   (-> {:handler-fn app :port port}
+      :sqs-queue c/aws-sqs-slack-router-auth-queue
+      :slack-sqs-msg-handler slack-router/sqs-handler
+      :sqs-creds {:access-key c/aws-access-key-id
+                  :secret-key c/aws-secret-access-key}
       components/auth-system
       component/start)
 

--- a/src/oc/auth/app.clj
+++ b/src/oc/auth/app.clj
@@ -58,7 +58,7 @@
     "Database: " c/db-name "\n"
     "Database pool: " c/db-pool-size "\n"
     "AWS SQS email queue: " c/aws-sqs-email-queue "\n"
-    "AWS SQS email queue: " c/aws-sqs-slack-router-auth-queue "\n"
+    "AWS SQS slack queue: " c/aws-sqs-slack-router-auth-queue "\n"
     "Trace: " c/liberator-trace "\n"
     "Hot-reload: " c/hot-reload "\n"
     "Sentry: " c/dsn "\n\n"

--- a/src/oc/auth/app.clj
+++ b/src/oc/auth/app.clj
@@ -89,11 +89,13 @@
     (timbre/merge-config! {:level (keyword c/log-level)}))
 
   ;; Start the system
-  (-> {:handler-fn app :port port}
-      :sqs-queue c/aws-sqs-slack-router-auth-queue
-      :slack-sqs-msg-handler slack-router/sqs-handler
-      :sqs-creds {:access-key c/aws-access-key-id
-                  :secret-key c/aws-secret-access-key}
+  (-> {:handler-fn app
+       :port port
+       :sqs-queue c/aws-sqs-slack-router-auth-queue
+       :slack-sqs-msg-handler slack-router/sqs-handler
+       :sqs-creds {:access-key c/aws-access-key-id
+                   :secret-key c/aws-secret-access-key}
+       }
       components/auth-system
       component/start)
 

--- a/src/oc/auth/async/slack_router.clj
+++ b/src/oc/auth/async/slack_router.clj
@@ -1,0 +1,115 @@
+(ns oc.auth.async.slack-router
+  "Consume slack messages from SQS. This SQS queue is subscribed to the Slack
+   message SNS topic.
+  "
+  (:require
+   [clojure.core.async :as async :refer (<!! >!!)]
+   [cheshire.core :as json]
+   [oc.lib.sqs :as sqs]
+   [oc.auth.config :as config]
+   [taoensso.timbre :as timbre]))
+
+;; ----- core.async -----
+
+(defonce slack-router-chan (async/chan 10000)) ; buffered channel
+
+(defonce slack-router-go (atom nil))
+
+(defn slack-event
+  "
+  Handle a message event from Slack. Ignore events that aren't threaded, or that are from us.
+  Idea here is to do very minimal processing and get a 200 back to Slack as fast as possible as this is a 'fire hose'
+  of requests. So minimal logging and minimal handling of the request.
+  Message events look like:
+  {'token' 'IxT9ZaxvjqRdKxYtWdTw21Xv',
+   'team_id' 'T06SBMH60',
+   'api_app_id' 'A0CHN2UDB',
+   'event' {'type' 'message',
+            'user' 'U06SBTXJR',
+            'text' 'Call me back here',
+            'thread_ts' '1494262410.072574',
+            'parent_user_id' 'U06SBTXJR',
+            'ts' '1494281750.011785',
+            'channel' 'C10A1P4H2',
+            'event_ts' '1494281750.011785'},
+    'type' 'event_callback',
+    'authed_users' ['U06SBTXJR'],
+    'event_id' 'Ev5B8YSYQ6',
+    'event_time' 1494281750}
+  "
+  [body]
+  (let [type (:type body)
+        token (:token body)
+        event (:event body)
+        channel (:channel event)
+        thread (:thread_ts event)]
+    (timbre/debug type event)
+    ;; Token check
+    (if-not (= token config/slack-verification-token)
+
+      ;; Eghads! It might be a Slack impersonator!
+      (timbre/warn "Slack verification token mismatch, request provided:" token)
+
+      ;; Token check is A-OK
+      (when (= type "event_callback")
+        (let [event (get body "event")
+              event-type (get event "type")]
+          
+          (when (= event-type "tokens_revoked")
+            (timbre/debug "TOKENS REVOKED: " event)))))))
+
+;; ----- SQS handling -----
+
+(defn- read-message-body
+  "
+  Try to parse as json, otherwise use read-string.
+  "
+  [msg]
+  (try
+    (json/parse-string msg true)
+    (catch Exception e
+      (read-string msg))))
+
+(defn sqs-handler
+  "Handle an incoming SQS message to the auth service."
+  [msg done-channel]
+  (let [msg-body (read-message-body (:body msg))
+        error (if (:test-error msg-body) (/ 1 0) false)] ; a message testing Sentry error reporting
+    (timbre/infof "Received message from SQS: %s\n" msg-body)
+    (>!! slack-router-chan msg-body))
+  (sqs/ack done-channel msg))
+
+;; ----- Event loop -----
+
+(defn- slack-router-loop
+  "Start a core.async consumer of the slack router channel."
+  []
+  (reset! slack-router-go true)
+  (async/go (while @slack-router-go
+      (timbre/info "Waiting for message on slack router channel...")
+      (let [msg (<!! slack-router-chan)]
+        (timbre/trace "Processing message on slack router channel...")
+        (if (:stop msg)
+          (do (reset! slack-router-go false) (timbre/info "Slack router stopped."))
+          (try
+            (when (:Message msg) ;; data change SNS message
+              (let [msg-parsed (json/parse-string (:Message msg) true)]
+                (slack-event msg-parsed)))
+            (timbre/trace "Processing complete.")
+            (catch Exception e
+              (timbre/error e))))))))
+
+;; ----- Component start/stop -----
+
+(defn start
+ "Stop the core.async slack router channel consumer."
+  []
+  (timbre/info "Starting slack router...")
+  (slack-router-loop))
+
+(defn stop
+ "Stop the core.async slack router channel consumer."
+  []
+  (when @slack-router-go
+    (timbre/info "Stopping slack router...")
+    (>!! slack-router-chan {:stop true})))

--- a/src/oc/auth/async/slack_router.clj
+++ b/src/oc/auth/async/slack_router.clj
@@ -62,12 +62,11 @@
                              conn
                              :slack-orgs
                              slack-team-id)]
+                  (slack-res/delete-slack-org! conn slack-team-id)
                   (doseq [team teams]
                     (team-res/remove-slack-org conn
                                                (:team-id team)
-                                               slack-team-id)
-                    (slack-res/delete-slack-org! conn slack-team-id)))))))))))
-
+                                               slack-team-id)))))))))))
 ;; ----- SQS handling -----
 
 (defn- read-message-body

--- a/src/oc/auth/async/slack_router.clj
+++ b/src/oc/auth/async/slack_router.clj
@@ -58,13 +58,15 @@
           (when (= event-type "tokens_revoked")
             (let [slack-team-id (:team_id body)]
               (pool/with-pool [conn db-pool]
-                (let [team (:team-id (first
-                                      (team-res/list-teams-by-index
-                                         conn
-                                         :slack-orgs
-                                         slack-team-id)))]
-                  (team-res/remove-slack-org conn team slack-team-id)
-                  (slack-res/delete-slack-org! conn slack-team-id))))))))))
+                (let [teams (team-res/list-teams-by-index
+                             conn
+                             :slack-orgs
+                             slack-team-id)]
+                  (doseq [team teams]
+                    (team-res/remove-slack-org conn
+                                               (:team-id team)
+                                               slack-team-id)
+                    (slack-res/delete-slack-org! conn slack-team-id)))))))))))
 
 ;; ----- SQS handling -----
 

--- a/src/oc/auth/components.clj
+++ b/src/oc/auth/components.clj
@@ -48,7 +48,7 @@
 
   (start [component]
     (timbre/info "[slack-router] starting...")
-    (slack-router/start)
+    (slack-router/start component)
     (timbre/info "[slack-router] started")
     (assoc component :slack-router true))
 
@@ -66,7 +66,7 @@
    :db-pool (map->RethinkPool {:size c/db-pool-size :regenerate-interval 5})
    :slack-router (component/using
                   (map->SlackRouter {:slack-router-fn slack-sqs-msg-handler})
-                  [])
+                  [:db-pool])
    :sqs (sqs/sqs-listener sqs-creds sqs-queue slack-sqs-msg-handler)
    :handler (component/using
              (map->Handler {:handler-fn handler-fn})

--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -59,6 +59,7 @@
 
 (defonce aws-sqs-bot-queue (env :aws-sqs-bot-queue))
 (defonce aws-sqs-email-queue (env :aws-sqs-email-queue))
+(defonce aws-sqs-slack-router-auth-queue (env :aws-sqs-slack-router-auth-queue))
 
 ;; ----- JWT -----
 
@@ -68,6 +69,7 @@
 
 (defonce slack-client-id (env :open-company-slack-client-id))
 (defonce slack-client-secret (env :open-company-slack-client-secret))
+(defonce slack-verification-token (env :open-company-slack-verification-token))
 (defonce slack-user-scope "identity.basic,identity.team,identity.avatar,identity.email")
 (defonce slack-comment-scope "users:read,users:read.email,team:read,chat:write:user,channels:read,channels:history")
 (defonce slack-unfurl-scope "links:read,links:write")


### PR DESCRIPTION
Slack has a 'Remove App' button on each app page.  This button is meant for a slack user to remove any added application to their workspace.  An event is generated `tokens_revoked` from slack when this occurs.  This change to auth subscribes the auth service to events in the slack router and when the `tokens_revoked` event occurs it probably removes the slack information.

Deploy to staging with https://github.com/belucid/open-company-infrastructure/pull/65

To test:
- Run the slack router service and follow the instructions to get slack events:
https://github.com/open-company/open-company-slack-router#slack-proxy-ngrok
- Subscribe an SQS queue to the slack events.  Set this queue in your environment ie 
`export AWS_SQS_SLACK_ROUTER_AUTH_QUEUE=carrot-local-slack-router-auth-dev-nathan`

- Signup with slack with local dev.
- Visit the slack app page https://opencompanyhq.slack.com/apps/A5SGHA79P-carrot-local-development?page=1  
- [x] After clicking remove app and logging in again are you asked to add the bot?