### PR TITLE
Slack invite message link to the new slack signup lander.

### DIFF
--- a/src/oc/auth/lib/sqs.clj
+++ b/src/oc/auth/lib/sqs.clj
@@ -113,7 +113,7 @@
     :org-logo-height (or (:logo-height payload) 0)
     :first-name (or (:first-name payload) "")
     :note (or (:note payload) "")
-    :url config/ui-server-url
+    :url (str config/ui-server-url "/sign-up/slack")
     :receiver {:slack-org-id (:slack-org-id payload)
                :type receiver
                :id (:slack-id payload)}


### PR DESCRIPTION
Card: https://trello.com/c/iGGEOL3v

Abstract: https://share.goabstract.com/a66dac87-f6ee-43e7-b3b8-5190419df2a4

To test:
- invite a user via Slack
- [x] did you get the message in Slack? Good
- [x] the url is not simply a homepage link but it points to /sign-up/slack? Good
- [x] do you see the new slack lander there (check the abstract link above)? Good
- invite another user via email
- [x] did you get an email link with the one time token? Good