### PR TITLE
Send an SNS message when a new user is created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ You will also need to subscribe the SQS `aws-sqs-slack-router-auth-queue` queue 
 
 Go to the AWS SQS Console and select the SQS queue configured above. From the 'Queue Actions' dropdown, select 'Subscribe Queue to SNS Topic'. Select the SNS topic you've configured your Slack Router service instance to publish to, and click the 'Subscribe' button.
 
+An [AWS SNS](https://aws.amazon.com/sns/) pub/sub topic is used to push user events to interested listeners, such as the [OpenCompany Storage service](https://github.com/open-company/open-company-storage). To take advantage of this capability, configure the `aws-sns-auth-topic-arn` with the ARN (Amazon Resource Name) of an SNS topic you setup in AWS. Then follow the instructions in the other services to subscribe to the SNS topic with an SQS queue.
+
+
 Make sure you update the `CHANGE-ME` items in the section of the `project.clj` that looks like this to contain your actual JWT, Slack, and AWS secrets:
 
 ```clojure
@@ -196,6 +199,7 @@ Make sure you update the `CHANGE-ME` items in the section of the `project.clj` t
     :aws-sqs-bot-queue "CHANGE-ME"
     :aws-sqs-email-queue "CHANGE-ME"
     :aws-sqs-slack-router-auth-queue "CHANGE-ME"
+    :aws-sns-auth-topic-arn "CHANGE-ME"
     :log-level "debug"
   }
 ```

--- a/src/oc/auth/api/google.clj
+++ b/src/oc/auth/api/google.clj
@@ -10,6 +10,7 @@
             [oc.auth.lib.jwtoken :as jwtoken]
             [oc.auth.resources.user :as user-res]
             [oc.auth.config :as config]
+            [oc.auth.async.notification :as notification]
             [oc.auth.representations.user :as user-rep]))
 
 (defn- redirect-to-web-ui
@@ -42,7 +43,10 @@
 (defn- create-user-for
   [conn new-user]
   (timbre/info "Creating new user:" (:email new-user) (:first-name new-user) (:last-name new-user))
-  (user-res/create-user! conn (assoc new-user :status :active)))
+  (let [user (user-res/create-user! conn (assoc new-user :status :active))
+        trigger (notification/->trigger user)]
+    (notification/send-trigger! trigger)
+    user))
 
 (def auth-req
   (oauth2/make-auth-request config/google))

--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -15,6 +15,7 @@
             [oc.auth.lib.sqs :as sqs]
             [oc.auth.lib.jwtoken :as jwtoken]
             [oc.auth.api.slack :as slack-api]
+            [oc.auth.async.notification :as notification]
             [oc.auth.resources.team :as team-res]
             [oc.auth.resources.user :as user-res]
             [oc.auth.representations.media-types :as mt]
@@ -104,6 +105,8 @@
                  config/aws-sqs-email-queue
                  (if (not= (keyword (:status created-user)) :pending) 900 0))
       (timbre/info "Sent email verification for:" user-id "(" email ")")
+      (timbre/info "Sending notification to SNS topic for:" user-id "(" email ")")
+      (notification/send-trigger! (notification/->trigger created-user))
       {:new-user (assoc created-user :admin admin-teams)})
     
     (do

--- a/src/oc/auth/app.clj
+++ b/src/oc/auth/app.clj
@@ -62,6 +62,7 @@
     "AWS SQS email queue: " c/aws-sqs-email-queue "\n"
     "AWS SQS bot queue: " c/aws-sqs-bot-queue "\n"
     "AWS SQS slack queue: " c/aws-sqs-slack-router-auth-queue "\n"
+    "AWS SNS notification topic ARN: " c/aws-sns-auth-topic-arn "\n"
     "Trace: " c/liberator-trace "\n"
     "Hot-reload: " c/hot-reload "\n"
     "Sentry: " c/dsn "\n\n"

--- a/src/oc/auth/async/notification.clj
+++ b/src/oc/auth/async/notification.clj
@@ -68,8 +68,12 @@
 
 (defn ->trigger
   [user]
-  (let [fixed-user (assoc user :name
-                          (str (:first-name user) " " (:last-name user)))]
+  (let [full-name (str (:first-name user) " " (:last-name user))
+        name (if (clojure.string/blank? full-name)
+               ;; email users don't have a name yet
+               "New User" ;; use temporary name for SNS message schema
+               full-name)
+        fixed-user (assoc user :name name)]
     {:notification-type :add
      :resource-type :user
      :content {:new fixed-user}

--- a/src/oc/auth/async/notification.clj
+++ b/src/oc/auth/async/notification.clj
@@ -81,8 +81,7 @@
 
 (schema/defn ^:always-validate send-trigger! [trigger :- UserTrigger]
   (when-not (clojure.string/blank? config/aws-sns-auth-topic-arn)
-    (do
-      (>!! notification-chan trigger))))
+    (>!! notification-chan trigger)))
 
 ;; ----- Component start/stop -----
 

--- a/src/oc/auth/async/notification.clj
+++ b/src/oc/auth/async/notification.clj
@@ -1,0 +1,96 @@
+(ns oc.auth.async.notification
+  "
+  Async publish of notification events to AWS SNS.
+  "
+  (:require [clojure.core.async :as async :refer (<! >!!)]
+            [taoensso.timbre :as timbre]
+            [cheshire.core :as json]
+            [amazonica.aws.sns :as sns]
+            [schema.core :as schema]
+            [oc.lib.schema :as lib-schema]
+            [oc.lib.time :as oc-time]
+            [oc.auth.config :as config]))
+
+;; ----- core.async -----
+
+(defonce notification-chan (async/chan 10000)) ; buffered channel
+
+(defonce notification-go (atom true))
+
+;; ----- Data schema -----
+
+(def UserTrigger
+  "
+  add - the content for a newly created user.
+  "
+  {:notification-type schema/Keyword
+   :resource-type schema/Keyword
+   :content {
+             (schema/optional-key :new) lib-schema/User}
+   :notification-at lib-schema/ISO8601})
+
+;; ----- Event handling -----
+
+(defn- handle-notification-message
+  [trigger]
+  (timbre/debug "Message request of:" (:notification-type trigger)
+                "to topic:" config/aws-sns-auth-topic-arn)
+  (timbre/trace "Message request:" trigger)
+  (schema/validate UserTrigger trigger)
+  (timbre/info "Sending request to topic:" config/aws-sns-auth-topic-arn)
+  (sns/publish
+    {:access-key config/aws-access-key-id
+     :secret-key config/aws-secret-access-key}
+     :topic-arn config/aws-sns-auth-topic-arn
+     :subject (str (name (:notification-type trigger))
+                   " on " (name (:resource-type trigger)))
+     :message (json/generate-string trigger {:pretty true}))
+  (timbre/info "Request sent to topic:" config/aws-sns-auth-topic-arn))
+
+;; ----- Event loop -----
+
+(defn- notification-loop []
+  (reset! notification-go true)
+  (timbre/info "Starting notification...")
+  (async/go (while @notification-go
+    (timbre/debug "Notification waiting...")
+    (let [message (<! notification-chan)]
+      (timbre/debug "Processing message on notification channel...")
+      (if (:stop message)
+        (do (reset! notification-go false) (timbre/info "Notification stopped."))
+        (async/thread
+          (try
+            (handle-notification-message message)
+          (catch Exception e
+            (timbre/error e)))))))))
+
+;; ----- Notification triggering -----
+
+(defn ->trigger
+  [user]
+  (let [fixed-user (assoc user :name
+                          (str (:first-name user) " " (:last-name user)))]
+    {:notification-type :add
+     :resource-type :user
+     :content {:new fixed-user}
+     :notification-at (oc-time/current-timestamp)}))
+
+(schema/defn ^:always-validate send-trigger! [trigger :- UserTrigger]
+  (when-not (clojure.string/blank? config/aws-sns-auth-topic-arn)
+    (do
+      (>!! notification-chan trigger))))
+
+;; ----- Component start/stop -----
+
+(defn start
+  "Start the core.async event loop."
+  []
+  (when-not (clojure.string/blank? config/aws-sns-auth-topic-arn) ;; do we care about getting SNS notifications?
+    (notification-loop)))
+
+(defn stop
+  "Stop the the core.async event loop."
+  []
+  (when @notification-go
+    (timbre/info "Stopping notification...")
+    (>!! notification-chan {:stop true})))

--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -61,6 +61,7 @@
 (defonce aws-sqs-email-queue (env :aws-sqs-email-queue))
 (defonce aws-sqs-slack-router-auth-queue (env :aws-sqs-slack-router-auth-queue))
 
+(defonce aws-sns-auth-topic-arn (env :aws-sns-auth-topic-arn))
 ;; ----- JWT -----
 
 (defonce passphrase (env :open-company-auth-passphrase))


### PR DESCRIPTION
This change adds a SNS message when a new user is created. This message is used by the storage service to make a new , uninvited user a contributor by default.

Needs 
https://github.com/belucid/open-company-infrastructure/pull/78
and
https://github.com/open-company/open-company-storage/pull/140

To test:

- Sign up and create a new org
- on org setup add a domain that automatically brings in new users
- Sign up using an email with that domain
- [x] Does the new user show up as a contributor?

- repeat above using google and slack. 