### PR TITLE
Contributor invite

### DIFF
--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -49,6 +49,7 @@
     ((set (:admins team)) user-id)
     false))
 
+
 (defn- valid-team-update? [conn team-id team-props]
   (if-let [team (team-res/get-team conn team-id)]
     (let [updated-team (merge team (team-res/clean team-props))]
@@ -283,7 +284,11 @@
   ;; Authorization
   :allowed? (by-method {
     :options true 
-    :post (fn [ctx] (allow-team-admins conn (:user ctx) team-id))}) ; team admins only
+    :post (fn [ctx] (do
+                      (timbre/debug ctx)
+                      (and (or (allow-team-admins conn (:user ctx) team-id)
+                               (not (-> ctx :data :admin)))
+                           (allow-team-members conn (:user ctx) team-id))))})
 
   ;; Existentialism
   :exists? (fn [ctx] (if-let [team (and (lib-schema/unique-id? team-id) (team-res/get-team conn team-id))]

--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -283,11 +283,9 @@
   ;; Authorization
   :allowed? (by-method {
     :options true 
-    :post (fn [ctx] (do
-                      (timbre/debug ctx)
-                      (and (or (allow-team-admins conn (:user ctx) team-id)
-                               (not (-> ctx :data :admin)))
-                           (allow-team-members conn (:user ctx) team-id))))})
+    :post (fn [ctx] (and (or (allow-team-admins conn (:user ctx) team-id)
+                             (not (-> ctx :data :admin)))
+                         (allow-team-members conn (:user ctx) team-id)))})
 
   ;; Existentialism
   :exists? (fn [ctx] (if-let [team (and (lib-schema/unique-id? team-id) (team-res/get-team conn team-id))]

--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -49,7 +49,6 @@
     ((set (:admins team)) user-id)
     false))
 
-
 (defn- valid-team-update? [conn team-id team-props]
   (if-let [team (team-res/get-team conn team-id)]
     (let [updated-team (merge team (team-res/clean team-props))]

--- a/src/oc/auth/representations/team.clj
+++ b/src/oc/auth/representations/team.clj
@@ -74,6 +74,7 @@
   "HATEOAS links for a team resource for a regular team member."
   [{team-id :team-id :as team}]
   (assoc team :links [(roster-link team-id)
+                      (invite-user-link team-id)
                       (channels-link team-id)]))
 
 (defn- email-domain


### PR DESCRIPTION
Allows contributors to send team invites instead of only admins.

