### PR TITLE
User superuser token to gather user information.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,17 +13,17 @@
 
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.0-alpha6"]
+    [org.clojure/clojure "1.10.0-alpha7"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.7"]
     [http-kit "2.3.0"] ; Web client/server http://http-kit.org/
     ;; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-devel "1.7.0-RC2"]
+    [ring/ring-devel "1.7.0"]
     ;; Web application library https://github.com/ring-clojure/ring
     ;; NB: clj-time pulled in by oc.lib
     ;; NB: joda-time pulled in by oc.lib via clj-time
     ;; NB: commons-codec pulled in by oc.lib
-    [ring/ring-core "1.7.0-RC2" :exclusions [clj-time joda-time commons-codec]]
+    [ring/ring-core "1.7.0" :exclusions [clj-time joda-time commons-codec]]
     ;; CORS library https://github.com/jumblerg/ring.middleware.cors
     [jumblerg/ring.middleware.cors "1.0.1"]
     ;; Ring logging https://github.com/nberger/ring-logger-timbre

--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -57,11 +57,10 @@
   [ctx]
   (let [token (api-common/get-token (get-in ctx [:request :headers]))]
     (if-let [decoded-token (jwt/decode token)]
-      (do
-        (if (and (jwt/check-token token config/passphrase)    ;; We signed the token
-                 (:super-user (:claims decoded-token)))
-          {:jwtoken decoded-token :user (:claims decoded-token)}
-          false))
+      (if (and (jwt/check-token token config/passphrase)    ;; We signed the token
+               (:super-user (:claims decoded-token)))
+        {:jwtoken decoded-token :user (:claims decoded-token)}
+        false)
       false)))
 
 (defn- allow-user-and-team-admins [conn ctx accessed-user-id]

--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -55,13 +55,14 @@
 
 (defn- allow-superuser-token
   [ctx]
-  (let [token (api-common/get-token (get-in ctx [:request :headers]))]
+  (if-let [token (api-common/get-token (get-in ctx [:request :headers]))]
     (if-let [decoded-token (jwt/decode token)]
       (if (and (jwt/check-token token config/passphrase)    ;; We signed the token
                (:super-user (:claims decoded-token)))
         {:jwtoken decoded-token :user (:claims decoded-token)}
         false)
-      false)))
+      false)
+    false))
 
 (defn- allow-user-and-team-admins [conn ctx accessed-user-id]
   (let [accessing-user-id (:user-id (:user ctx))]

--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -256,7 +256,7 @@
                         (or (allow-superuser-token ctx)
                             (api-common/read-token
                              (get-in ctx [:request :headers])
-                             config/passphrase))
+                             config/passphrase)))
   ;; Authorization
   :allowed? (by-method {
     :options true
@@ -333,7 +333,6 @@
                                                 (:id slack-user))
                                               (assoc :slack-token
                                                 (:token slack-user)))]
-                                (timbre/debug utoken token-user)
                                 ;; generated token
                                 {:jwtoken utoken :user token-user})))))))})
   

--- a/src/oc/auth/representations/user.clj
+++ b/src/oc/auth/representations/user.clj
@@ -17,7 +17,7 @@
             [oc.auth.representations.google-auth :as google-auth]
             [oc.auth.resources.user :as user-res]))
 
-(def slack-props [:name :slack-id :slack-org-id :slack-display-name])
+(def slack-props [:name :slack-id :slack-org-id :slack-display-name :slack-bots])
 (def oc-props [:user-id :first-name :last-name :email :avatar-url
                :digest-frequency :digest-medium :timezone
                :created-at :updated-at :slack-users])

--- a/src/oc/auth/resources/user.clj
+++ b/src/oc/auth/resources/user.clj
@@ -59,6 +59,7 @@
 (def User "User resource as stored in the DB."
   (merge UserCommon {
     :status (schema/pred #(statuses (keyword %)))
+    (schema/optional-key :slack-bots) (schema/maybe jwt/SlackBots)
     :created-at lib-schema/ISO8601
     :updated-at lib-schema/ISO8601}))
 


### PR DESCRIPTION
The storage service needs user information in order to do an auto share.  This change allows the storage service to make a request to get that info.

Supports: https://github.com/open-company/open-company-storage/pull/143

