### PR TITLE
Fix the mixed case email issue.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,12 +18,12 @@
     [org.clojure/tools.cli "0.3.7"]
     [http-kit "2.3.0"] ; Web client/server http://http-kit.org/
     ;; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-devel "1.7.0-RC1"]
+    [ring/ring-devel "1.7.0-RC2"]
     ;; Web application library https://github.com/ring-clojure/ring
     ;; NB: clj-time pulled in by oc.lib
     ;; NB: joda-time pulled in by oc.lib via clj-time
     ;; NB: commons-codec pulled in by oc.lib
-    [ring/ring-core "1.7.0-RC1" :exclusions [clj-time joda-time commons-codec]]
+    [ring/ring-core "1.7.0-RC2" :exclusions [clj-time joda-time commons-codec]]
     ;; CORS library https://github.com/jumblerg/ring.middleware.cors
     [jumblerg/ring.middleware.cors "1.0.1"]
     ;; Ring logging https://github.com/nberger/ring-logger-timbre
@@ -52,7 +52,7 @@
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
-    [open-company/lib "0.16.13" :exclusions [clj-http org.clojure/data.json]]
+    [open-company/lib "0.16.14" :exclusions [clj-http org.clojure/data.json]]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let
@@ -87,7 +87,7 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.2" :exclusions [joda-time clj-time commons-codec]] 
+        [midje "1.9.3-alpha1" :exclusions [joda-time clj-time commons-codec]] 
         ;; Test Ring requests https://github.com/weavejester/ring-mock
         [ring-mock "0.1.5"]
       ]
@@ -102,7 +102,7 @@
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure rewrite-clj org.clojure/tools.reader]]
         ;; Dependency of lein-kibit and lein-zprint https://github.com/xsc/rewrite-clj
         ;; NB: org.clojure/tools.reader pulled in manually
-        [rewrite-clj "0.6.0" :exclusions [org.clojure/tools.reader]]
+        [rewrite-clj "0.6.1" :exclusions [org.clojure/tools.reader]]
         ;; Not used directly, dependency of lein-kibit and rewrite-clj https://github.com/clojure/tools.reader
         [org.clojure/tools.reader "1.3.0"]
       ]
@@ -138,7 +138,7 @@
         ;; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
         [lein-spell "0.1.0"]
         ;; Dead code finder https://github.com/venantius/yagni
-        [venantius/yagni "0.1.4" :exclusions [org.clojure/clojure]]
+        [venantius/yagni "0.1.6" :exclusions [org.clojure/clojure]]
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: rewrite-cljs not needed

--- a/src/oc/auth/db/migrations/1536085172215_lower_email_index.edn
+++ b/src/oc/auth/db/migrations/1536085172215_lower_email_index.edn
@@ -1,0 +1,17 @@
+(ns oc.auth.db.migrations.lower-email-index
+  (:require [rethinkdb.query :as r]
+            [oc.lib.db.migrations :as m]
+            [oc.auth.resources.user :as u]
+            [oc.auth.config :as config]))
+
+(defn up [conn]
+  (println "Creating index loweremail ")
+  (println (-> (r/table u/table-name)
+               (r/index-create "loweremails"
+                               (r/fn [row]
+                                     (r/downcase (r/get-field row :email))))
+               (r/run conn)))
+  (println (-> (r/table u/table-name)
+               (r/index-wait "loweremails")
+               (r/run conn)))
+  true) ; return true on success

--- a/src/oc/auth/resources/user.clj
+++ b/src/oc/auth/resources/user.clj
@@ -189,7 +189,8 @@
   "Given the email address of the user, retrieve them from the database, or return nil if user doesn't exist."
   [conn email :- lib-schema/NonBlankStr]
   {:pre [(db-common/conn? conn)]}
-  (first (db-common/read-resources conn table-name "email" email)))
+  (let [loweremail (clojure.string/lower-case email)]
+    (first (db-common/read-resources conn table-name "loweremails" loweremail))))
 
 (schema/defn ^:always-validate get-user-by-token :- (schema/maybe User)
   "Given the one-time-use token of the user, retrieve them from the database, or return nil if user doesn't exist."


### PR DESCRIPTION
This change uses a lower case index for email. When querying for email use the new index along with downcasing the email.

To test:

- signup with any email
- logout
- attempt to sign up with the same email but using mixed case
- do you get the 'Email already exists' error?