### PR TITLE
Refresh google token. 

### DIFF
--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -14,6 +14,7 @@
             [oc.auth.config :as config]
             [oc.auth.lib.sqs :as sqs]
             [oc.auth.lib.jwtoken :as jwtoken]
+            [oc.auth.lib.google :as google]
             [oc.auth.api.slack :as slack-api]
             [oc.auth.async.notification :as notification]
             [oc.auth.resources.team :as team-res]
@@ -356,7 +357,10 @@
                         "slack" (slack-api/refresh-token conn (:existing-user ctx)
                                                               (-> ctx :user :slack-id)
                                                               (-> ctx :user :slack-token))
-        
+                        "google" (let [user (:existing-user ctx)]
+                                   (if (google/refresh-token conn user)
+                                     (user-rep/auth-response conn user :google)
+                                     (api-common/unauthorized-response)))
                         ;; What token is this?
                         (api-common/unauthorized-response))))
 

--- a/src/oc/auth/lib/google.clj
+++ b/src/oc/auth/lib/google.clj
@@ -1,0 +1,33 @@
+(ns oc.auth.lib.google
+  "OAuth2 convenience functions for google."
+  (:require [taoensso.timbre :as timbre]
+            [clojure.walk :refer (keywordize-keys)]
+            [cheshire.core :as json]
+            [clj-oauth2.client :as oauth2]
+            [oc.auth.config :as config]
+            [oc.auth.resources.user :as user-res]))
+
+(def auth-req
+  (oauth2/make-auth-request config/google))
+
+(defn access-token [params]
+  (oauth2/get-access-token config/google (keywordize-keys params) auth-req))
+
+(defn user-info [access-token]
+  (let [response (oauth2/get "https://www.googleapis.com/oauth2/v1/userinfo"
+                             {:oauth2 access-token})]
+    (keywordize-keys (json/parse-string (:body response)))))
+
+
+(defn refresh-token
+  "Check if token has expired. If expired send false, otherwise return the token. "
+  [conn user-info]
+  (let [expires-in (get-in user-info [:google-users
+                                      :token
+                                      :params
+                                      :expires_in])]
+    (timbre/info expires-in)
+    (if (pos? expires-in)
+      user-info
+      false)))
+  


### PR DESCRIPTION
We currently don't ask for the `offline` scope so we can't automatically refresh the google token. Instead this change checks the expiration time and returns the same token if not expired. The user will be logged out if expired.

To test: 

Use the NUX branch https://github.com/open-company/open-company-web/pull/661
- Sign up with google
- [x] After creating the team does the NUX continue?

You can also wait or modify the expiration time to test that it logs the user out of the web app.
