### PR TITLE
Strip tags on invite note

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,12 +48,10 @@
     [clj-http "3.9.1"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/clojure/data.json
     [org.clojure/data.json "0.2.6"]
-    ;; String library
-    [funcool/cuerdas "2.0.6"]
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
-    [open-company/lib "0.16.14" :exclusions [clj-http org.clojure/data.json]]
+    [open-company/lib "0.16.16alpha" :exclusions [clj-http org.clojure/data.json]]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,8 @@
     [clj-http "3.9.1"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/clojure/data.json
     [org.clojure/data.json "0.2.6"]
-    
+    ;; String library
+    [funcool/cuerdas "2.0.6"]
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually

--- a/src/oc/auth/lib/google.clj
+++ b/src/oc/auth/lib/google.clj
@@ -4,8 +4,7 @@
             [clojure.walk :refer (keywordize-keys)]
             [cheshire.core :as json]
             [clj-oauth2.client :as oauth2]
-            [oc.auth.config :as config]
-            [oc.auth.resources.user :as user-res]))
+            [oc.auth.config :as config]))
 
 (def auth-req
   (oauth2/make-auth-request config/google))

--- a/src/oc/auth/lib/sqs.clj
+++ b/src/oc/auth/lib/sqs.clj
@@ -87,7 +87,7 @@
     :to (:email payload)
     :from (or from "")
     :from-avatar (or from-avatar "")
-    :note (or (str/strip-tags (:note payload) ["script" "style"]) "")
+    :note (or (str/strip-tags (:note payload) ["script" "style" "input"]) "")
     :reply-to (or reply-to "")
     :first-name (or (:first-name payload) "")
     :org-name (or (:org-name payload) "")
@@ -113,7 +113,7 @@
     :org-logo-width (or (:logo-width payload) 0)
     :org-logo-height (or (:logo-height payload) 0)
     :first-name (or (:first-name payload) "")
-    :note (or (str/strip-tags (:note payload) ["script" "style"]) "")
+    :note (or (str/strip-tags (:note payload) ["script" "style" "input"]) "")
     :url (str config/ui-server-url "/sign-up/slack")
     :receiver {:slack-org-id (:slack-org-id payload)
                :type receiver

--- a/src/oc/auth/lib/sqs.clj
+++ b/src/oc/auth/lib/sqs.clj
@@ -3,8 +3,8 @@
             [amazonica.aws.sqs :as sqs]
             [taoensso.timbre :as timbre]
             [schema.core :as schema]
-            [cuerdas.core :as str]
             [oc.lib.schema :as lib-schema]
+            [oc.lib.text :as str]
             [oc.auth.config :as config]))
 
 ;; SQS message types
@@ -87,7 +87,7 @@
     :to (:email payload)
     :from (or from "")
     :from-avatar (or from-avatar "")
-    :note (or (str/strip-tags (:note payload) ["script" "style" "input"]) "")
+    :note (or (str/strip-xss-tags (:note payload)) "")
     :reply-to (or reply-to "")
     :first-name (or (:first-name payload) "")
     :org-name (or (:org-name payload) "")
@@ -113,7 +113,7 @@
     :org-logo-width (or (:logo-width payload) 0)
     :org-logo-height (or (:logo-height payload) 0)
     :first-name (or (:first-name payload) "")
-    :note (or (str/strip-tags (:note payload) ["script" "style" "input"]) "")
+    :note (or (str/strip-xss-tags (:note payload)) "")
     :url (str config/ui-server-url "/sign-up/slack")
     :receiver {:slack-org-id (:slack-org-id payload)
                :type receiver

--- a/src/oc/auth/lib/sqs.clj
+++ b/src/oc/auth/lib/sqs.clj
@@ -3,6 +3,7 @@
             [amazonica.aws.sqs :as sqs]
             [taoensso.timbre :as timbre]
             [schema.core :as schema]
+            [cuerdas.core :as str]
             [oc.lib.schema :as lib-schema]
             [oc.auth.config :as config]))
 
@@ -86,7 +87,7 @@
     :to (:email payload)
     :from (or from "")
     :from-avatar (or from-avatar "")
-    :note (or (:note payload) "")
+    :note (or (str/strip-tags (:note payload) ["script" "style"]) "")
     :reply-to (or reply-to "")
     :first-name (or (:first-name payload) "")
     :org-name (or (:org-name payload) "")
@@ -112,7 +113,7 @@
     :org-logo-width (or (:logo-width payload) 0)
     :org-logo-height (or (:logo-height payload) 0)
     :first-name (or (:first-name payload) "")
-    :note (or (:note payload) "")
+    :note (or (str/strip-tags (:note payload) ["script" "style"]) "")
     :url (str config/ui-server-url "/sign-up/slack")
     :receiver {:slack-org-id (:slack-org-id payload)
                :type receiver


### PR DESCRIPTION
To address this issue https://github.com/open-company/open-company-storage/pull/158#issuecomment-429079097

Strip out the script and style tags.

To test follow the suggestions in the above comment.

- Invite a user and added that script tag in the note field, sent via cURL:
```
curl -i \
 -H "Access-Control-Allow-Headers: Content-Type, Authorization" \
 -H "Accept: application/vnd.open-company.user.v1+json" \
 -H "Authorization: Bearer YOUR_JWT_HERE" \
-H "Content-Type: application/vnd.open-company.team.invite.v1" \
-X POST -d @/path/to/payload.json \
http://localhost:3003/teams/4264-4cea-876d/users/
```

/path/to/payload.json is:
```
{"admin": false,
"email": "bago2k4+11OctA1@gmail.com",
"first-name": "",
"last-name": "",
"logo-height": 0,
"logo-url": null,
"logo-width": 0,
"note": "<script>alert('malicious goes here');</script>",
"org-name": "11 October 5"}
```