### PR TITLE
Allow us to easily use the REPL for DB access only

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -186,7 +186,7 @@
   :repl-options {
     :welcome (println (str "\n" (slurp (clojure.java.io/resource "ascii_art.txt")) "\n"
                       "OpenCompany Auth REPL\n"
-                      "\nReady to do your bidding... I suggest (go) or (go <port>) as your first command.\n"))
+                      "\nReady to do your bidding... I suggest (go) or (go <port>) or (go-db) as your first command.\n"))
       :init-ns dev
   }
 

--- a/src/dev.clj
+++ b/src/dev.clj
@@ -21,6 +21,9 @@
                                                       :secret-key c/aws-secret-access-key}
                                           :port port})))))
 
+(defn init-db []
+  (alter-var-root #'system (constantly (components/db-only-auth-system {}))))
+
 (defn bind-conn! []
   (alter-var-root #'conn (constantly (pool/claim (get-in system [:db-pool :pool])))))
 
@@ -29,6 +32,13 @@
 
 (defn stop []
   (alter-var-root #'system (fn [s] (when s (component/stop s)))))
+
+(defn go-db []
+  (init-db)
+  (start)
+  (bind-conn!)
+  (println (str "A DB connection is available with: conn\n"
+                "When you're ready to stop the system, just type: (stop)\n")))
 
 (defn go
 

--- a/src/dev.clj
+++ b/src/dev.clj
@@ -27,7 +27,7 @@
 (defn bind-conn! []
   (alter-var-root #'conn (constantly (pool/claim (get-in system [:db-pool :pool])))))
 
-(defn start []
+(defn- start⬆ []
   (alter-var-root #'system component/start))
 
 (defn stop []
@@ -35,7 +35,7 @@
 
 (defn go-db []
   (init-db)
-  (start)
+  (start⬆)
   (bind-conn!)
   (println (str "A DB connection is available with: conn\n"
                 "When you're ready to stop the system, just type: (stop)\n")))
@@ -46,7 +46,7 @@
   
   ([port]
   (init port)
-  (start)
+  (start⬆)
   (bind-conn!)
   (app/echo-config port)
   (println (str "Now serving auth from the REPL.\n"

--- a/src/oc/auth/components.clj
+++ b/src/oc/auth/components.clj
@@ -83,6 +83,10 @@
         (dissoc component :async-consumers))
     component)))
 
+(defn db-only-auth-system [_opts]
+  (component/system-map
+   :db-pool (map->RethinkPool {:size c/db-pool-size :regenerate-interval 5})))
+
 (defn auth-system [{:keys [port handler-fn sqs-creds sqs-queue slack-sqs-msg-handler]}]
   (component/system-map
    :db-pool (map->RethinkPool {:size c/db-pool-size :regenerate-interval 5})

--- a/src/oc/auth/lib/google.clj
+++ b/src/oc/auth/lib/google.clj
@@ -4,8 +4,7 @@
             [clojure.walk :refer (keywordize-keys)]
             [cheshire.core :as json]
             [clj-oauth2.client :as oauth2]
-            [oc.auth.config :as config]
-            [oc.auth.resources.user :as user-res]))
+            [oc.auth.config :as config]))
 
 (def auth-req
   (oauth2/make-auth-request config/google))


### PR DESCRIPTION
No trello card.

Sometimes we need to be able to run the REPL for only DB access w/o running all the other components in the service. This PR makes it easy with `(go-db)`.

To test:

- Launch a REPL
- Run `(go-db)`
- Access DB with `(team/list-teams conn)`
- [x] All good?
- Stop with `(stop)`
- [x] All good?
- Regression test with `(go)`
- Stop with `(stop)`
- [x] All good?
- Merge