### PR TITLE
Add slack bot info to user when authenticating with google.

### DIFF
--- a/src/oc/auth/api/google.clj
+++ b/src/oc/auth/api/google.clj
@@ -4,6 +4,7 @@
             [compojure.core :as compojure :refer (defroutes GET OPTIONS)]
             [ring.util.response :as response]
             [oc.lib.db.pool :as pool]
+            [oc.lib.jwt :as jwt]
             [oc.auth.lib.jwtoken :as jwtoken]
             [oc.auth.lib.google :as google]
             [oc.auth.resources.user :as user-res]
@@ -69,6 +70,9 @@
             jwt-user (user-rep/jwt-props-for (-> updated-google-user
                                                (clean-user)
                                                (assoc :admin (user-res/admin-of conn (:user-id user)))
+                                               ;; include slack bot info
+                                               (assoc :slack-bots
+                                                 (jwt/bots-for conn user))
                                                (assoc :google-id (:id user-info))
                                                (assoc :google-domain (:hd user-info))
                                                (assoc :google-token token)) :google)]

--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -359,7 +359,11 @@
                                                               (-> ctx :user :slack-token))
                         "google" (let [user (:existing-user ctx)]
                                    (if (google/refresh-token conn user)
-                                     (user-rep/auth-response conn user :google)
+                                     (user-rep/auth-response
+                                       conn
+                                       (assoc user :slack-bots
+                                              (jwt/bots-for conn user))
+                                       :google)
                                      (api-common/unauthorized-response)))
                         ;; What token is this?
                         (api-common/unauthorized-response))))


### PR DESCRIPTION
This change includes the slack bot info for the jwt token.  This will prevent errors when sharing or inviting to slack.

To test:
- sign up with slack
- add the bot
- logout and signin with google (same email address as slack)
- create a section with auto-share to slack turned on
- [x] do you get an error when posting to that section?
- [x] does the post get auto shared?
- [x] do you get an error without these changes?

- merge
- deploy