### PR TITLE
Default avatar url if avatar url is empty.

### DIFF
--- a/src/oc/auth/resources/user.clj
+++ b/src/oc/auth/resources/user.clj
@@ -137,15 +137,15 @@
     false))
 
 ;; ----- User CRUD -----
-(def default-user-image "/img/ML/happy_face_red.svg")
-(def other-user-images
- ["/img/ML/happy_face_green.svg"
+(def user-images
+ ["/img/ML/happy_face_red.svg")
+  "/img/ML/happy_face_green.svg"
   "/img/ML/happy_face_blue.svg"
   "/img/ML/happy_face_purple.svg"
   "/img/ML/happy_face_yellow.svg"])
 
 (defn random-user-image []
-  (first (shuffle (vec (conj other-user-images default-user-image)))))
+  (first (shuffle (vec user-images))))
 
 (schema/defn ^:always-validate ->user :- User
   "Take a minimal map describing a user and 'fill the blanks' with any missing properties."

--- a/src/oc/auth/resources/user.clj
+++ b/src/oc/auth/resources/user.clj
@@ -137,6 +137,15 @@
     false))
 
 ;; ----- User CRUD -----
+(def default-user-image "/img/ML/happy_face_red.svg")
+(def other-user-images
+ ["/img/ML/happy_face_green.svg"
+  "/img/ML/happy_face_blue.svg"
+  "/img/ML/happy_face_purple.svg"
+  "/img/ML/happy_face_yellow.svg"])
+
+(defn random-user-image []
+  (first (shuffle (vec (conj other-user-images default-user-image)))))
 
 (schema/defn ^:always-validate ->user :- User
   "Take a minimal map describing a user and 'fill the blanks' with any missing properties."
@@ -156,7 +165,7 @@
         (update :email #(or % ""))
         (update :first-name #(or % ""))
         (update :last-name #(or % ""))
-        (update :avatar-url #(or % ""))
+        (update :avatar-url #(or % (random-user-image)))
         (update :digest-frequency #(or % :daily))
         (update :digest-medium #(or % :email)) ; lowest common denominator
         (assoc :status :pending)

--- a/src/oc/auth/resources/user.clj
+++ b/src/oc/auth/resources/user.clj
@@ -138,7 +138,7 @@
 
 ;; ----- User CRUD -----
 (def user-images
- ["/img/ML/happy_face_red.svg")
+ ["/img/ML/happy_face_red.svg"
   "/img/ML/happy_face_green.svg"
   "/img/ML/happy_face_blue.svg"
   "/img/ML/happy_face_purple.svg"


### PR DESCRIPTION
Adds an avatar url to the user info if none is provided.

To test: (NOTE: the test steps currently works with mainline web at commit e2c260b3a3a)

- create an org
- invite a user via email
- [x] is the invite sent?  (this is when the default avatar url is used)
- login with the new invited user
- [x] does the user have a jelly head avatar?