### PR TITLE
Return false if user is already a member

### DIFF
--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -85,7 +85,7 @@
   ;; An already active team member... who is inviting this person, yoh?
   ([_conn _sender team user :guard #(= :active (keyword (:status %))) true _admin? _invite]
   (timbre/warn "Invite request for existing active team member" (:user-id user) "of team" (:team-id team))
-  true)
+  false)
   
   ;; No user yet, email invite
   ([conn sender team nil member? admin? invite :guard :email]

--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -85,7 +85,7 @@
   ;; An already active team member... who is inviting this person, yoh?
   ([_conn _sender team user :guard #(= :active (keyword (:status %))) true _admin? _invite]
   (timbre/warn "Invite request for existing active team member" (:user-id user) "of team" (:team-id team))
-  false)
+  user)
   
   ;; No user yet, email invite
   ([conn sender team nil member? admin? invite :guard :email]


### PR DESCRIPTION
Returning true causes the following sentry error https://sentry.io/opencompany/oc-beta-auth/issues/761670163/?referrer=slack

Returning false will report an error to the user.


To test:

- invite an existing team member that has an active email.
- [x] do you not get the error?
