### PR TITLE
Use the right rel for google auth link.

### DIFF
--- a/src/oc/auth/representations/team.clj
+++ b/src/oc/auth/representations/team.clj
@@ -42,7 +42,7 @@
   (slack/bot-link team-id))
 
 (defn add-google-auth-link [team-id]
-  (google/auth-link team-id))
+  (google/auth-link "authenticate" team-id))
 
 (defn roster-link [team-id]
   (hateoas/link-map "roster" hateoas/GET (str (url team-id) "/roster") {:accept mt/user-collection-media-type}))


### PR DESCRIPTION
NB: not sure this fix is needed, since i am not sure a google auth link is ever needed to users that already have a team. It's not like Slack.

To test: if you can think of a case where you can assoc a google account once you are already logged in use it. If not let's just merge to avoid future wrong uses of that link.