### PR TITLE
Slack avatar and name fix

### DIFF
--- a/src/oc/auth/lib/slack.clj
+++ b/src/oc/auth/lib/slack.clj
@@ -31,7 +31,9 @@
     {:user-id (db-common/unique-id)
      :slack-id (:id user-data)
      :slack-org-id (:team_id user-data)
-     :slack-display-name (:name user-data)
+     :slack-display-name (or (:display_name_normalized user-data)
+                             (:display_name user-data)
+                             (:name user-data))
      :name (:real_name user-data)
      :first-name (or (:first_name user-data)
                      (cond

--- a/src/oc/auth/lib/slack.clj
+++ b/src/oc/auth/lib/slack.clj
@@ -129,9 +129,10 @@
           ;; valid response and access token
           ;; w/ identity.basic this response contains all user information we can get
           ;; so munge that into the right shape, or get user info if that doesn't work
-          (let [user (if user-profile
-                        (coerce-to-user user-profile team-profile)
-                        (get-user-info access-token scope slack-id))]
+          (let [user-info (remove clojure.string/blank? (get-user-info access-token scope slack-id))
+                user (if user-profile
+                       (merge (coerce-to-user user-profile team-profile) user-info)
+                       user-info)]
             ;; return user and Slack org info
             (merge user slack-org splitted-state {:bot slack-bot :slack-token access-token}))
 

--- a/src/oc/auth/lib/slack.clj
+++ b/src/oc/auth/lib/slack.clj
@@ -129,9 +129,10 @@
           ;; valid response and access token
           ;; w/ identity.basic this response contains all user information we can get
           ;; so munge that into the right shape, or get user info if that doesn't work
-          (let [user-info (remove clojure.string/blank? (get-user-info access-token scope slack-id))
+          (let [user-info (get-user-info access-token scope slack-id)
+                non-empty-user-info (apply merge (for [[k v] user-info :when (not (nil? v))] {k v}))
                 user (if user-profile
-                       (merge (coerce-to-user user-profile team-profile) user-info)
+                       (merge (coerce-to-user user-profile team-profile) non-empty-user-info)
                        user-info)]
             ;; return user and Slack org info
             (merge user slack-org splitted-state {:bot slack-bot :slack-token access-token}))

--- a/src/oc/auth/lib/slack.clj
+++ b/src/oc/auth/lib/slack.clj
@@ -130,7 +130,7 @@
           ;; w/ identity.basic this response contains all user information we can get
           ;; so munge that into the right shape, or get user info if that doesn't work
           (let [user-info (get-user-info access-token scope slack-id)
-                non-empty-user-info (apply merge (for [[k v] user-info :when (not (nil? v))] {k v}))
+                non-empty-user-info (apply merge (for [[k v] user-info :when (not (clojure.string/blank? v))] {k v}))
                 user (if user-profile
                        (merge (coerce-to-user user-profile team-profile) non-empty-user-info)
                        user-info)]

--- a/src/oc/auth/resources/team.clj
+++ b/src/oc/auth/resources/team.clj
@@ -45,6 +45,7 @@
   (schema/optional-key :logo-height) (schema/maybe schema/Int)
   (schema/optional-key :first-name) (schema/maybe schema/Str)
   (schema/optional-key :last-name) (schema/maybe schema/Str)
+  (schema/optional-key :avatar-url) (schema/maybe schema/Str)
   (schema/optional-key :note) (schema/maybe schema/Str)
   (schema/optional-key :email) (schema/maybe lib-schema/EmailAddress)})
 


### PR DESCRIPTION
Card: https://trello.com/c/bGSPC7Ux

Review with: https://github.com/open-company/open-company-web/pull/795

Test 1: needed to make sure the avatar is saved from Slack to Carrot
Test 2: needed to make sure a user that was invited but that has no first/last name yet (for example invited via email) is picking his first/last name, the avatar and other properties (title and timezone) from Slack.

Test missing avatar
- *test 1*
- onboard a Slack user
- add the bot
- invite a user via Slack
- go to Team Management
- [x] do you see the new user as pending? Good
- [x] does he has the Slack avatar? Good
- log in on Slack with the invited user
- sign up with the invited user
- [x] were you NOT asked for first/last name? Good
- [ ] do you have the Slack avatar already set? Good
- *test 2*
- now invite another Slack user but *via email* this time
- now sign up in Carrot via Slack SSO with the invited user
- [x] were you NOT asked for first/last name? Good
- [x] do you see your the user's Slack avatar in Carrot? Good