### PR TITLE
Needs try/catch when getting user info from slack

### DIFF
--- a/src/oc/auth/lib/slack.clj
+++ b/src/oc/auth/lib/slack.clj
@@ -130,7 +130,11 @@
           ;; valid response and access token
           ;; w/ identity.basic this response contains all user information we can get
           ;; so munge that into the right shape, or get user info if that doesn't work
-          (let [user-info (get-user-info access-token scope slack-id)
+          (let [user-info (try
+                            (get-user-info access-token scope slack-id)
+                            (catch Exception e
+                              (timbre/info e)
+                              {}))
                 non-empty-user-info (apply merge (for [[k v] user-info :when (not (clojure.string/blank? v))] {k v}))
                 user (if user-profile
                        (merge (coerce-to-user user-profile team-profile) non-empty-user-info)


### PR DESCRIPTION
We might not have the correct scopes to get user info and should use try/catch.

