### PR TITLE
Prepare team schema for billing migration

### DIFF
--- a/src/oc/auth/resources/team.clj
+++ b/src/oc/auth/resources/team.clj
@@ -21,6 +21,7 @@
   :email-domains [lib-schema/EmailDomain]
   :slack-orgs [lib-schema/NonBlankStr]
   (schema/optional-key :logo-url) (schema/maybe schema/Str)
+  (schema/optional-key :stripe-customer-id) (schema/maybe schema/Str)
   :created-at lib-schema/ISO8601
   :updated-at lib-schema/ISO8601})
 


### PR DESCRIPTION
Must be merged and deployed before deploying #93.

Billing migration strategy is as follows: 

~0. Deploy `:stripe-customer-id` schema to auth to avoid breakage (that is this PR, the one you're reading right now)~
~1. First we’ll need to flip our test product/plans into production mode in Stripe. Pretty sure this is a click of a button.~
~2. Make sure prod env vars for api key, product ID, and default plan are set correctly (flipping them to production mode will generate new IDs)~
~3. For each existing customer:~
    - ~Update their `team` db record with their respective `:stripe-customer-id`~
    - ~Create a private plan matching Stuart’s requirements (see the google doc)~
    - ~Use the REPL to call `(stripe/create-subscription! customer-id custom-plan-id {"billing_cycle_anchor" start-time, "prorate" false})` which will subscribe them to the given custom plan set to start/invoice at the given time~
    - ~Force a seat usage update by calling `(payments-async/report-team-seat-usage! conn team-id)`~
4. Deploy auth and web to prod (PR #93)