### PR TITLE
Fix user remove

### DIFF
--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -203,6 +203,18 @@
     (do (timbre/info "Deleted team:" team-id) true)
     (do (timbre/error "Failed deleting team:" team-id) false)))
 
+(defn- remove-team-member [conn team-id member-id admin?]
+  (timbre/info "Removing user" member-id "from team" team-id)
+  (let [updated-user (user-res/remove-team conn member-id team-id)]
+    (when admin?
+      (timbre/info "User is an admin, removing from admins of team" team-id)
+      (team-res/remove-admin conn team-id member-id))
+    (when (empty? (:teams updated-user))
+      (timbre/info "User has no other team left, deleting user" member-id)
+      (user-res/delete-user! conn member-id))
+    (timbre/info "User" member-id "removed from team" team-id)
+    {:updated-team (team-res/get-team conn team-id)}))
+
 ;; ----- Resources - see: http://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg
 
 (defresource team-list [conn]
@@ -367,6 +379,36 @@
   ;; Responses
   :respond-with-entity? false
   :handle-created (fn [ctx] (when-not (:updated-team ctx) (api-common/missing-response)))
+  :handle-no-content (fn [ctx] (when-not (:updated-team ctx) (api-common/missing-response))))
+
+(defresource member [conn team-id member-id]
+  (api-common/open-company-authenticated-resource config/passphrase) ; verify validity and presence of required JWToken
+
+  :allowed-methods [:options :delete]
+
+  ;; Media type client accepts
+  :available-media-types [mt/user-media-type]
+  :handle-not-acceptable (api-common/only-accept 406 mt/user-media-type)
+
+  ;; Media type client sends
+  :malformed? false ; no check, this media type is blank
+
+  ;; Auhorization
+  :allowed? (by-method {
+    :options true
+    :delete (fn [ctx] (allow-team-admins conn (:user ctx) team-id))})
+
+  ;; Existentialism
+  :exists? (fn [ctx] (if-let* [team (and (lib-schema/unique-id? team-id) (team-res/get-team conn team-id))
+                               user (and (lib-schema/unique-id? member-id) (user-res/get-user conn member-id))
+                               member? ((set (:teams user)) (:team-id team))]
+                        {:existing-user user :admin? ((set (:admins team)) member-id)}
+                        false)) ; no team, no user, or user not a member of the team
+
+  ;; Actions
+  :delete! (fn [ctx] (remove-team-member conn team-id member-id (:admin? ctx)))
+
+  ;; Responses
   :handle-no-content (fn [ctx] (when-not (:updated-team ctx) (api-common/missing-response))))
 
 ;; A resource for the email domains of a particular team
@@ -547,6 +589,9 @@
       ;; Invite user to team
       (ANY "/teams/:team-id/users" [team-id] (pool/with-pool [conn db-pool] (invite conn team-id)))
       (ANY "/teams/:team-id/users/" [team-id] (pool/with-pool [conn db-pool] (invite conn team-id)))
+      ;; Remove user from team
+      (ANY "/teams/:team-id/users/:member-id" [team-id member-id] (pool/with-pool [conn db-pool] (member conn team-id member-id)))
+      (ANY "/teams/:team-id/users/:member-id/" [team-id member-id] (pool/with-pool [conn db-pool] (member conn team-id member-id)))
       ;; Team admin operations
       (ANY "/teams/:team-id/admins/:user-id" [team-id user-id]
         (pool/with-pool [conn db-pool] (admin conn team-id user-id)))

--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -272,7 +272,7 @@
 (defresource user [conn user-id]
   (api-common/open-company-authenticated-resource config/passphrase) ; verify validity and presence of required JWToken
 
-  :allowed-methods [:options :get :post :patch :delete]
+  :allowed-methods [:options :get :post :patch]
 
   ;; Media type client accepts
   :available-media-types [mt/user-media-type]
@@ -282,16 +282,14 @@
     :options false
     :get false
     :post false
-    :patch (fn [ctx] (api-common/malformed-json? ctx))
-    :delete false})
+    :patch (fn [ctx] (api-common/malformed-json? ctx))})
   
   ;; Media type client sends
   :known-content-type? (by-method {
                           :options true
                           :get true
                           :post true
-                          :patch (fn [ctx] (api-common/known-content-type? ctx mt/user-media-type))
-                          :delete true})
+                          :patch (fn [ctx] (api-common/known-content-type? ctx mt/user-media-type))})
 
   :initialize-context (fn [ctx]
                         (or (allow-superuser-token ctx)
@@ -303,16 +301,14 @@
     :options true
     :get (fn [ctx] (allow-user-and-team-admins conn ctx user-id))
     :post (fn [ctx] (allow-user-and-team-admins conn ctx user-id))
-    :patch (fn [ctx] (allow-user-and-team-admins conn ctx user-id))
-    :delete (fn [ctx] (allow-user-and-team-admins conn ctx user-id))})
+    :patch (fn [ctx] (allow-user-and-team-admins conn ctx user-id))})
 
   ;; Validations
   :processable? (by-method {
     :get true
     :options true
     :post (fn [ctx] (can-resend-verificaiton-email? conn user-id))
-    :patch (fn [ctx] (valid-user-update? conn (:data ctx) user-id))
-    :delete true})
+    :patch (fn [ctx] (valid-user-update? conn (:data ctx) user-id))})
 
   ;; Existentialism
   :exists? (fn [ctx] (if-let [user (and (lib-schema/unique-id? user-id)
@@ -327,7 +323,6 @@
   ;; Acctions
   :post! (fn [ctx] (resend-verification-email conn ctx user-id))
   :patch! (fn [ctx] (update-user conn ctx user-id))
-  :delete! (fn [_] (delete-user conn user-id))
 
   ;; Responses
   :handle-ok (by-method {

--- a/src/oc/auth/api/users.clj
+++ b/src/oc/auth/api/users.clj
@@ -170,12 +170,6 @@
 
     (do (timbre/error "Failed updating user:" user-id) false)))
 
-(defn- delete-user [conn user-id]
-  (timbre/info "Deleting user:" user-id)
-  (if (user-res/delete-user! conn user-id)
-    (do (timbre/info "Deleted user:" user-id) true)
-    (do (timbre/error "Failed deleting user:" user-id) false)))
-
 (defn password-reset-request [conn email]
   (timbre/info "Password reset request for:" email)
   (if-let [user (user-res/get-user-by-email conn email)]

--- a/src/oc/auth/representations/user.clj
+++ b/src/oc/auth/representations/user.clj
@@ -33,6 +33,9 @@
 (defn- admin-url [team-id user-id]
   (s/join "/" ["/teams" team-id "admins" user-id]))
 
+(defn- team-member-url [team-id user-id]
+  (s/join "/" ["/teams" team-id "users" user-id]))
+
 (defn- self-link [user-id] (hateoas/self-link (url user-id) {:accept mt/user-media-type}))
 
 (defn- item-link [user-id] (hateoas/item-link (url user-id) {:accept mt/user-media-type}))
@@ -44,7 +47,7 @@
 
 (defn- delete-link [user-id] (hateoas/delete-link (url user-id) {:ref mt/user-media-type}))
 
-(defn- remove-link [user-id] (hateoas/remove-link (url user-id) {} {:ref mt/user-media-type}))
+(defn- remove-link [team-id user-id] (hateoas/remove-link (team-member-url team-id user-id) {} {:ref mt/user-media-type}))
 
 (defn- resend-verification-email-link [user-id]
   (hateoas/link-map "resend-verification" hateoas/POST (str (url user-id) "/verify") {}))
@@ -103,7 +106,7 @@
       (item-link user-id)
       (partial-update-link user-id)
       (admin-action-link team-id user-id (:admin? user))
-      (remove-link user-id)])))
+      (remove-link team-id user-id)])))
 
 (defn- user-links
   "HATEOAS links for a user resource"


### PR DESCRIPTION
Bug: right now when a user is removed from a team we directly delete the user w/o caring if he's part of another team or if he's an admin of the current one.

Fix: remove the DELETE method from the current user resource to avoid cancellation of users by mistake. Add a new endpoint to remove a user from a team: first check if he's an admin of the current team, if so remove him from the admins, then remove the user from the team, finally check if there are teams left for the user, if he's an orphan (user has no teams left) completely delete the user.

To test:
- signup with a new org
- invite a user
- before accepting the invite go to manage team and cancel the invitation
- [x] check auth logs: do you see the action to remove the user and to completely delete the user?
- now invite another user as admin
- accept the invite
- delete the user from user management (with another admin)
- [x] check auth logs: do you see the action to remove the user, remove the admin and to completely delete the user?
- now invite another user as admin (let's call him user 1)
- accept the invite
- signup with a new user and create a new org
- invite the user 1 to this new team too
- [ ] user is active right away? No invite you can cancel or resend?
- now remove user 1 from the team
- check Auth logs: 
- [x] do you see the action to remove the user from the team?
- [x] does it says it will remove the admin?
- [x] does it NOT say it will completely delete the user (since he has other teams left)?
- merge
- [ ] if #93 has been merged already add a seats report on user remove (in `oc.auth.api.teams/remove-team-member`)
- deploy

Questions:
- should we let a user remove himself?
- should we let the last user remove himself from the team?
- should we let the last admin remove himself from the team?
- should we delete a user when he has no teams left? if we keep it in the system he will be redirected to org creation the next time he logs in

NB: UI currently doesn't let you remove yourself from a team or change your role if you are an admin so the above are all covered by our client, but not if someone calls the API directly.