### PR TITLE
Economize Stripe API calls to alleviate some rate limiting issues

### DIFF
--- a/src/oc/auth/async/payments.clj
+++ b/src/oc/auth/async/payments.clj
@@ -43,15 +43,14 @@
         (timbre/debug "Processing message on payments channel...")
         (if (:stop message)
           (do (reset! payments-go false) (timbre/info "Payments loop stopped."))
-          (async/thread
-            (try
-              (handle-payments-message message)
-              ;; we're overwhelming Stripe, slow down
-              (catch RateLimitException e
-                (<! (async/timeout 500))
-                (async/put! payments-chan message))
-              (catch Exception e
-                (timbre/error e)))))))))
+          (try
+            (handle-payments-message message)
+            ;; we're overwhelming Stripe, slow down
+            (catch RateLimitException e
+              (<! (async/timeout 1000))
+              (async/put! payments-chan message))
+            (catch Exception e
+              (timbre/error e))))))))
 
 ;; ----- Payments triggering -----
 

--- a/src/oc/auth/async/payments.clj
+++ b/src/oc/auth/async/payments.clj
@@ -7,7 +7,8 @@
             [schema.core :as schema]
             [oc.auth.resources.payments :as pay-res]
             [oc.auth.resources.user :as user-res]
-            [oc.auth.resources.team :as team-res]))
+            [oc.auth.resources.team :as team-res])
+  (:import [com.stripe.exception RateLimitException]))
 
 ;; ----- core.async -----
 
@@ -35,17 +36,22 @@
 (defn- payments-loop []
   (reset! payments-go true)
   (timbre/info "Starting payments loop...")
-  (async/go (while @payments-go
-    (timbre/debug "Payments loop waiting...")
-    (let [message (<! payments-chan)]
-      (timbre/debug "Processing message on payments channel...")
-      (if (:stop message)
-        (do (reset! payments-go false) (timbre/info "Payments loop stopped."))
-        (async/thread
-          (try
-            (handle-payments-message message)
-          (catch Exception e
-            (timbre/error e)))))))))
+  (async/go
+    (while @payments-go
+      (timbre/debug "Payments loop waiting...")
+      (let [message (<! payments-chan)]
+        (timbre/debug "Processing message on payments channel...")
+        (if (:stop message)
+          (do (reset! payments-go false) (timbre/info "Payments loop stopped."))
+          (async/thread
+            (try
+              (handle-payments-message message)
+              ;; we're overwhelming Stripe, slow down
+              (catch RateLimitException e
+                (<! (async/timeout 500))
+                (async/put! payments-chan message))
+              (catch Exception e
+                (timbre/error e)))))))))
 
 ;; ----- Payments triggering -----
 

--- a/src/oc/auth/lib/stripe.clj
+++ b/src/oc/auth/lib/stripe.clj
@@ -212,7 +212,7 @@
      :full-name     (.getName customer)
      :subscriptions (sort-by :current-period-start subs)}))
 
-(defn- enrich-customer
+(defn enrich-customer
   [customer]
   (let [customer-id      (:id customer)
         pay-methods      (list-payment-methods customer-id)
@@ -226,9 +226,8 @@
 (defn get-customer
   "Retrieves a summary of the given customer ID."
   [customer-id]
-  (-> (Customer/retrieve customer-id)
-      convert-customer
-      enrich-customer))
+  (convert-customer
+   (Customer/retrieve customer-id)))
 
 (defn create-customer!
   "Creates a Customer object in the Stripe API and returns it.

--- a/src/oc/auth/resources/payments.clj
+++ b/src/oc/auth/resources/payments.clj
@@ -40,7 +40,8 @@
    team-id :- (:team-id team/Team)]
   {:pre [(db-common/conn? conn)]}
   (when-let [customer-id (get-customer-id conn team-id)]
-    (stripe/get-customer customer-id)))
+    (stripe/enrich-customer
+     (stripe/get-customer customer-id))))
 
 (schema/defn ^:always-validate start-new-trial!
   [conn


### PR DESCRIPTION
To test:

- From staging web, open JS console and run `for (var i = 0; i < 100; i++) { OCWebForceRefreshToken(); }`. This will cause 100 very rapid seat update calls to Stripe.
- [x] No rate limiting alerts/errors?