### PR TITLE
Fix migration path for non-admin customers

### DIFF
--- a/src/oc/auth/api/payments.clj
+++ b/src/oc/auth/api/payments.clj
@@ -62,7 +62,7 @@
   [ctx conn team-id]
   (let [;; FIXME: starting to complect with team
         team         (team-res/get-team conn team-id)
-        first-admin  (-> team :admins first)
+        first-admin  (->> team :admins first (user-res/get-user conn))
         contact      {:email     (:email first-admin)
                       :full-name (lib-user/name-for first-admin)}
         new-customer (payments-res/create-customer! conn team-id contact)]

--- a/src/oc/auth/api/payments.clj
+++ b/src/oc/auth/api/payments.clj
@@ -58,11 +58,13 @@
 
 ;; ----- Actions -----
 
-(defn- create-customer-with-creator-as-contact!
+(defn- create-customer-with-admin-as-contact!
   [ctx conn team-id]
-  (let [creator      (:user ctx)
-        contact      {:email     (:email creator)
-                      :full-name (lib-user/name-for creator)}
+  (let [;; FIXME: starting to complect with team
+        team         (team-res/get-team conn team-id)
+        first-admin  (-> team :admins first)
+        contact      {:email     (:email first-admin)
+                      :full-name (lib-user/name-for first-admin)}
         new-customer (payments-res/create-customer! conn team-id contact)]
     (payments-res/start-new-trial! conn team-id config/stripe-default-plan-id)
     (payments-async/report-team-seat-usage! conn team-id)
@@ -133,7 +135,7 @@
   :exists? (fn [ctx] (if-let [customer (payments-res/get-customer conn team-id)]
                        {:existing-customer customer}
                        ;; on-demand creation
-                       (create-customer-with-creator-as-contact! ctx conn team-id)))
+                       (create-customer-with-admin-as-contact! ctx conn team-id)))
 
   ;; Actions
   :post! (fn [ctx] (schedule-plan-change! ctx conn team-id))


### PR DESCRIPTION
create a new org not using the sub-billing branch, invite a user that’s a viewer, switch to the sub-billing branch, and then log in with that viewer