### PR TITLE
Fix annual start

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,12 +18,12 @@
     [org.clojure/tools.cli "0.4.2"]
     [http-kit "2.4.0-alpha4"] ; Web client/server http://http-kit.org/
     ;; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-devel "1.7.1"]
+    [ring/ring-devel "1.8.0"]
     ;; Web application library https://github.com/ring-clojure/ring
     ;; NB: clj-time pulled in by oc.lib
     ;; NB: joda-time pulled in by oc.lib via clj-time
     ;; NB: commons-codec pulled in by oc.lib
-    [ring/ring-core "1.7.1" :exclusions [clj-time joda-time commons-codec]]
+    [ring/ring-core "1.8.0" :exclusions [clj-time joda-time commons-codec]]
     ;; CORS library https://github.com/jumblerg/ring.middleware.cors
     [jumblerg/ring.middleware.cors "1.0.1"]
     ;; Ring logging https://github.com/nberger/ring-logger-timbre
@@ -43,18 +43,18 @@
     ;; Authentication for ring https://github.com/funcool/buddy-auth
     [buddy/buddy-auth "2.2.0"]
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
-    [zprint "0.4.16"]
+    [zprint "0.5.3"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/dakrone/clj-http
     [clj-http "3.10.0"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/clojure/data.json
-    [org.clojure/data.json "0.2.6"]
+    [org.clojure/data.json "0.2.7"]
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
     ;; Java library for the Stripe API https://github.com/stripe/stripe-java
-    [com.stripe/stripe-java "13.1.0"]
+    [com.stripe/stripe-java "16.2.0"]
 
-    [open-company/lib "0.17.18-alpha" :exclusions [clj-http org.clojure/data.json]]
+    [open-company/lib "0.17.24" :exclusions [clj-http org.clojure/data.json]]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let
@@ -95,13 +95,13 @@
       ]
       :plugins [
         ;; Example-based testing https://github.com/marick/lein-midje
-        [lein-midje "3.2.1"]
+        [lein-midje "3.2.2"]
         ;; Linter https://github.com/jonase/eastwood
         [jonase/eastwood "0.3.6"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: org.clojure/tools.reader pulled in manually
-        [lein-kibit "0.1.7" :exclusions [org.clojure/clojure rewrite-clj org.clojure/tools.reader]]
+        [lein-kibit "0.1.8" :exclusions [org.clojure/clojure rewrite-clj org.clojure/tools.reader]]
         ;; Dependency of lein-kibit and lein-zprint https://github.com/xsc/rewrite-clj
         ;; NB: org.clojure/tools.reader pulled in manually
         [rewrite-clj "0.6.1" :exclusions [org.clojure/tools.reader]]
@@ -145,7 +145,7 @@
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: rewrite-cljs not needed
-        [lein-zprint "0.3.16" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
+        [lein-zprint "0.5.3" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
       ]
     }]
 

--- a/src/oc/auth/api/payments.clj
+++ b/src/oc/auth/api/payments.clj
@@ -18,7 +18,8 @@
             [clojure.edn :as edn]
             [ring.util.codec :as codec]
             [ring.util.request :as request]
-            [clojure.walk :refer (keywordize-keys)])
+            [clojure.walk :refer (keywordize-keys)]
+            [taoensso.timbre :as timbre])
   (:import [java.util Base64]
            [java.net URL]))
 
@@ -73,6 +74,7 @@
 
 (defn- create-customer-with-admin-as-contact!
   [ctx conn team-id]
+  (timbre/info "Creating customer for team" team-id)
   (let [;; FIXME: starting to complect with team
         team         (team-res/get-team conn team-id)
         first-admin  (->> team :admins first (user-res/get-user conn))
@@ -81,17 +83,20 @@
         new-customer (payments-res/create-customer! conn team-id contact)]
     (payments-res/start-new-trial! conn team-id config/stripe-default-plan-id)
     (payments-async/report-team-seat-usage! conn team-id)
+    (timbre/info "Customer created" (:id new-customer) "with email" (:email contact))
     {:new-customer new-customer}))
 
 (defn- schedule-plan-change!
   [ctx conn team-id]
   (when-let [plan-id (:plan-id ctx)]
     (payments-res/schedule-new-subscription! conn team-id plan-id)
+    (timbre/info "Scheduled plan change for team" team-id "to plan" plan-id)
     {:updated-customer (payments-res/get-customer conn team-id)}))
 
 (defn- cancel-subscription!
   [ctx conn team-id]
   (payments-res/cancel-subscription! conn team-id)
+  (timbre/info "Cancelled subscription for team" team-id)
   {:updated-customer (payments-res/get-customer conn team-id)})
 
 (defn- wrap-redirect-urls
@@ -107,6 +112,7 @@
 
 (defn- create-checkout-session!
   [ctx conn team-id]
+  (timbre/info "Creating checkout session for team" team-id)
   (let [redirects    (:checkout-redirects ctx)
         callbacks    (wrap-redirect-urls redirects)
         session      (payments-res/create-checkout-session! conn team-id callbacks)]
@@ -209,6 +215,7 @@
   )
 
 (defn checkout-session-success [conn req session-id state]
+  (timbre/info "Checkout success redirect" session-id)
   (let [decoder   (Base64/getUrlDecoder)
         redirects (->> state (.decode decoder) (String.) edn/read-string)
         success-url (:success-url redirects)
@@ -217,23 +224,27 @@
                      "UTF-8")
         success-url-params (parse-params (.getQuery parsed-success-url) encoding)
         current-customer (payments-res/customer-from-session session-id)
-        current-subscription (-> current-customer :subscriptions first)]
+        current-subscription (-> current-customer :subscriptions first)
+        should-switch-plan? (and (seq (:update-plan success-url-params))
+                                 (= (count (:subscriptions current-customer)) 1)
+                                 (= (:status current-subscription) "trialing")
+                                 (not= (-> current-subscription :plan :id) (:update-plan success-url-params))
+                                 (some #(when (= (:id %) (:update-plan success-url-params)) %) (:available-plans current-customer)))]
+    (timbre/info "Checkout session with switch plan" (:update-plan success-url-params) "will update?" should-switch-plan?)
     ;; In case they want to switch to a different plan
     ;; while they are still on trial (and so have only one subscription still)
     ;; and the new plan does exist
-    (when (and (seq (:update-plan success-url-params))
-               (= (count (:subscriptions current-customer)) 1)
-               (= (:status current-subscription) "trialing")
-               (not= (-> current-subscription :plan :id) (:update-plan success-url-params))
-               (some #(when (= (:id %) (:update-plan success-url-params)) %) (:available-plans current-customer)))
+    (when should-switch-plan?
       (payments-res/update-subscription-item-plan! (-> current-subscription :item :id) (:update-plan success-url-params)))
     ;; finish checkout to actually charge the newly added card
     (payments-res/finish-checkout-session! conn session-id)
     ;; finish the trial period if still trialing
     (payments-res/end-trial-period! conn (:id current-customer))
+    (timbre/info "Checkout success redirecting to web UI for" session-id)
     (response/redirect (:success-url redirects))))
 
 (defn checkout-session-cancel [conn session-id state]
+  (timbre/info "Checkout cancel redirect" session-id)
   (let [decoder   (Base64/getUrlDecoder)
         redirects (->> state (.decode decoder) (String.) edn/read-string)]
     (response/redirect (:cancel-url redirects))))

--- a/src/oc/auth/lib/stripe.clj
+++ b/src/oc/auth/lib/stripe.clj
@@ -338,6 +338,13 @@
                      "cancel_url"           cancel-url}
                     opts))))
 
+(defn customer-from-session
+  "Retrieve the customer from the sessionID"
+  [session-id]
+  (let [session  (Session/retrieve session-id)
+        customer-id (.getClientReferenceId session)]
+    (get-customer customer-id)))
+
 (defn assoc-session-result-with-customer!
   "Callback for the session created with `create-checkout-session!`. Once customer
   has entered payment method info, this callback should be invoked in order to

--- a/src/oc/auth/resources/payments.clj
+++ b/src/oc/auth/resources/payments.clj
@@ -43,6 +43,10 @@
     (stripe/enrich-customer
      (stripe/get-customer customer-id))))
 
+(schema/defn ^:always-validate customer-from-session
+  [session-id]
+  (stripe/enrich-customer (stripe/customer-from-session session-id)))
+
 (schema/defn ^:always-validate start-new-trial!
   [conn
    team-id :- (:team-id team/Team)
@@ -66,6 +70,11 @@
   (let [customer-id (get-customer-id conn team-id)
         customer    (stripe/get-customer customer-id)]
     (stripe/cancel-all-subscriptions! customer)))
+
+(schema/defn ^:always-validate update-subscription-item-plan!
+  [item-id
+   plan-id]
+  (stripe/update-subscription-item-plan! item-id plan-id))
 
 (schema/defn ^:always-validate report-latest-team-size!
   [customer-id :- (:id Customer)


### PR DESCRIPTION
Review with: https://github.com/open-company/open-company-web/pull/1073

BUG this PR fixes: if you signup and try to start with an annual plan you get charged with monthly and the annual plan is added as a second subscription starting in a month from now.

Also, this PR adds some logs around billing actions and some debug logs around Stripe actions.

To test fix:
- signup
- go to billing
- pick annual
- add card
- [x] did it work? are you on annual? date and price look good?
- [x] go to Stripe dashboard and check the user has the right subscription and they have only one invoice for the annual plan
- signup with another email/org
- pick monthly
- add a card
- [x] did it work? are you on monthly? date and price look good?
- [x] go to Stripe dashboard and check the user has the right subscription and they have only one invoice for the monthly plan

Test UI fix:
- assign a custom plan to one of the previous orgs from the Stripe dashboard
- go back in the client
- [x] do you see the custom plan as selected?
- [x] do you see the custom plan in the dropdown?
- pick another plan from the dropdown (don't save)
- [x] can you still see the custom plan in the dropdown?


Bug i coudn't fix for now:
- signup
- open billing
- switch to annual plan
- add a card
- once you are back in the client change to monthly plan
- save
- [ ] you get an error saying: `com.stripe.exception.InvalidRequestException: billing_cycle_anchor cannot be later than next natural billing date (1576958923) for plan;`

NB: the timestamp there makes no sense, it's like 2 seconds ago which we can't use as billing date since the user just pain an annual plan so the billing date of the monthly plan should be when the paid annual ends. Not sure if the issue here is the just canceled subscription.