### PR TITLE
Local config improvements

### DIFF
--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -50,7 +50,7 @@
 
 ;; ----- URLs -----
 
-(defonce host "localhost")
+(defonce host (or (env :local-dev-host) "localhost"))
 
 (defonce auth-server-url (or (env :auth-server-url) (str "http://" host ":" auth-server-port)))
 (defonce ui-server-url (or (env :ui-server-url) (str "http://" host ":3559")))

--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -50,10 +50,12 @@
 
 ;; ----- URLs -----
 
-(defonce auth-server-url (or (env :auth-server-url) (str "http://localhost:" auth-server-port)))
-(defonce ui-server-url (or (env :ui-server-url) "http://localhost:3559"))
-(defonce storage-server-url (or (env :storage-server-url) "http://localhost:3001"))
-(defonce dashboard-url (or (env :oc-dashboard-endpoint) "http://localhost:4001"))
+(defonce host "localhost")
+
+(defonce auth-server-url (or (env :auth-server-url) (str "http://" host ":" auth-server-port)))
+(defonce ui-server-url (or (env :ui-server-url) (str "http://" host ":3559")))
+(defonce storage-server-url (or (env :storage-server-url) (str "http://" host ":3001")))
+(defonce dashboard-url (or (env :oc-dashboard-endpoint) (str "http://" host ":4001")))
 
 ;; ----- AWS SQS -----
 


### PR DESCRIPTION
Relates to this https://github.com/open-company/open-company-storage/pull/235 but independent.

Use a single host var so we have to change only one value to do local testing.
Make it possible to set it in the environment.

To test:
- add `export local-dev-host=YOUR_IP_HERE`
- start auth
- check that it listens on your local network ip address instead of localhost