### PR TITLE
Clean user's data responses

### DIFF
--- a/src/oc/auth/representations/user.clj
+++ b/src/oc/auth/representations/user.clj
@@ -19,12 +19,13 @@
 
 (def slack-props [:name :slack-id :slack-org-id :slack-display-name :slack-bots])
 (def oc-props [:user-id :first-name :last-name :email :avatar-url
-               :digest-medium :notification-medium :reminder-medium :timezone
-               :created-at :updated-at :slack-users :status :qsg-checklist
-               :expo-push-tokens :title :blurb :location :profiles])
+               :timezone :created-at :slack-users :status :title :blurb :location :profiles])
 (def representation-props (concat slack-props oc-props))
-(def team-user-representation-props (concat representation-props [:admin?]))
-(def jwt-props [:user-id :first-name :last-name :name :email :avatar-url :teams :admin])
+(def self-user-props [:digest-medium :notification-medium :reminder-medium :updated-at :qsg-checklist :expo-push-tokens :digest-delivery :digest-last-at])
+(def team-user-props [:admin?])
+(def self-user-representation-props (concat representation-props self-user-props))
+(def team-user-representation-props (concat representation-props team-user-props))
+(def jwt-props [:user-id :first-name :last-name :name :email :avatar-url :teams :admin :digest-delivery :digest-last-at])
 
 (defun url
   ([user-id :guard string?] (str "/users/" user-id))
@@ -121,6 +122,21 @@
       (resend-verification-email-link user-id)
       add-expo-push-token-link])))
 
+(defn- clean-user-tokens [user]
+  (as-> user u
+   (if (:slack-users u)
+     (update u :slack-users (fn [slack-users]
+                              (apply merge
+                               (map (fn [[slack-team-id slack-values]]
+                                      (hash-map slack-team-id (dissoc slack-values :token))) slack-users))))
+     u)
+   (if (:google-users u)
+     (update u :google-users (fn [google-users]
+                              (apply merge
+                               (map (fn [[google-team-id google-values]]
+                                      (hash-map google-team-id (dissoc google-values :token))) google-users))))
+     u)))
+
 (schema/defn ^:always-validate jwt-props-for
   [user :- user-res/UserRep source :- schema/Keyword]
   (let [jwt-props (zipmap jwt-props (map user jwt-props))
@@ -164,6 +180,7 @@
   {:pre [(map? user)]}
   (let [user-id (:user-id user)]
     (-> user
+      (clean-user-tokens)
       (select-keys team-user-representation-props)
       (user-collection-links team-id))))
 
@@ -172,7 +189,7 @@
   [user :- user-res/User]
   (json/generate-string
     (-> user
-      (select-keys representation-props)
+      (select-keys self-user-representation-props)
       (assoc :password "")
       (user-links))
     {:pretty config/pretty?}))
@@ -186,7 +203,7 @@
        :collection {:version hateoas/json-collection-version
                     :href url
                     :links [(hateoas/self-link url {:accept mt/user-collection-media-type})]
-                    :items (map #(select-keys % team-user-representation-props) users)}}
+                    :items (map #(-> % (clean-user-tokens) (select-keys team-user-representation-props)) users)}}
       {:pretty config/pretty?})))
 
 (defn render-active-users-list


### PR DESCRIPTION
Right now when we render the list of users for a team or a roster we render the whole list of data.
That means we are including also some personal infos that we shouldn't send out.

Issue reproduction, on current `subscription-billing` branch:
- signup with Slack
- invite an email user
- accept invite
- make the email user an admin
- perform a team and roster call using the email user token
- can you see a token field in the `:slack-user` field of the initial user (the Slack one)?
- perform a user GET request with the email user JWT for the Slack user data
- can you see a token field in the `:slack-user` field of the initial user (the Slack one)?
- repeat signing up with Google SSO

To test the fix:
- repeat the steps above
- can you not see the tokens in the team/roster responses?
- can you not see the tokens in the user GET response of the email user?
- can you still see the tokens in the JWT of the Slack/Google user?
- can you still see the tokens in the user GET response for the Slack/Google user?