### PR TITLE
Invite throttle

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,7 @@
     ;; ***************** (JWT schema changes, more info here: *****************
     ;; ******* https://github.com/open-company/open-company-lib/pull/82) ******
     ;; ************************************************************************
-    [open-company/lib "0.20.1-alpha3" :exclusions [clj-http org.bouncycastle/bcpkix-jdk15on com.fasterxml.jackson.core/jackson-databind org.clojure/tools.reader]]
+    [open-company/lib "0.20.2-alpha" :exclusions [clj-http org.bouncycastle/bcpkix-jdk15on com.fasterxml.jackson.core/jackson-databind org.clojure/tools.reader]]
     ;; ************************************************************************
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually

--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,7 @@
     ;; ***************** (JWT schema changes, more info here: *****************
     ;; ******* https://github.com/open-company/open-company-lib/pull/82) ******
     ;; ************************************************************************
-    [open-company/lib "0.20.2-alpha3" :exclusions [clj-http org.bouncycastle/bcpkix-jdk15on com.fasterxml.jackson.core/jackson-databind org.clojure/tools.reader]]
+    [open-company/lib "0.20.2-alpha4" :exclusions [clj-http org.bouncycastle/bcpkix-jdk15on com.fasterxml.jackson.core/jackson-databind org.clojure/tools.reader]]
     ;; ************************************************************************
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually

--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,7 @@
     ;; ***************** (JWT schema changes, more info here: *****************
     ;; ******* https://github.com/open-company/open-company-lib/pull/82) ******
     ;; ************************************************************************
-    [open-company/lib "0.20.2-alpha" :exclusions [clj-http org.bouncycastle/bcpkix-jdk15on com.fasterxml.jackson.core/jackson-databind org.clojure/tools.reader]]
+    [open-company/lib "0.20.2-alpha3" :exclusions [clj-http org.bouncycastle/bcpkix-jdk15on com.fasterxml.jackson.core/jackson-databind org.clojure/tools.reader]]
     ;; ************************************************************************
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually

--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -331,8 +331,9 @@
                              slack-orgs (if (empty? slack-org-ids)
                                           []
                                           (slack-org-res/list-slack-orgs-by-ids conn slack-org-ids
-                                            [:bot-user-id :bot-token]))]
-                          (team-rep/render-team (assoc team-users :slack-orgs slack-orgs) (:user ctx))))
+                                            [:bot-user-id :bot-token]))
+                             full-user (user-res/get-user conn (:user-id (:user ctx)))]
+                          (team-rep/render-team (assoc team-users :slack-orgs slack-orgs) full-user)))
   :handle-unprocessable-entity (fn [ctx]
     (api-common/unprocessable-entity-handler (merge ctx {:reason (schema/check team-res/Team (:team-update ctx))}))))
 
@@ -685,9 +686,11 @@
   :respond-with-entity? true
   :post-enacted? true
   :handle-created (fn [ctx]
-                    (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)) (:user ctx)))
+                    (let [full-user (user-res/get-user conn (:user-id (:user ctx)))]
+                      (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)) full-user)))
   :handle-ok (fn [ctx]
-               (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)) (:user ctx))))
+               (let [full-user (user-res/get-user conn (:user-id (:user ctx)))]
+                 (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)) full-user))))
 
 ;; A resource for roster of team users for a particular team
 (defresource active-users [conn team-id]

--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -18,6 +18,7 @@
             [oc.auth.resources.team :as team-res]
             [oc.auth.resources.slack-org :as slack-org-res]
             [oc.auth.resources.user :as user-res]
+            [oc.auth.resources.invite-throttle :as invite-throttle]
             [oc.auth.representations.media-types :as mt]
             [oc.auth.representations.team :as team-rep]
             [oc.auth.representations.user :as user-rep]
@@ -68,7 +69,8 @@
   [conn user-id]
   (when-let* [user (user-res/get-user conn user-id)
             teams (:teams user)]
-    (team-res/list-teams-by-ids conn teams [:logo-url :admins :created-at :updated-at])))
+    (let [teams-data (team-res/list-teams-by-ids conn teams [:logo-url :admins :created-at :updated-at])]
+      (map #(assoc % :invite-throttle (invite-throttle/get-or-create! (:user-id user) (:team-id %))) teams-data))))
 
 ;; ----- Actions -----
 
@@ -277,8 +279,9 @@
   :handle-not-acceptable (api-common/only-accept 406 mt/team-collection-media-type)
 
   ;; Responses
-  :handle-ok (fn [ctx] (let [user (:user ctx)]
-                        (team-rep/render-team-list (teams-for-user conn (:user-id user)) user))))
+  :handle-ok (fn [ctx] (let [user (:user ctx)
+                             teams (teams-for-user conn (:user-id user))]
+                        (team-rep/render-team-list teams user))))
 
 ;; A resource for operations on a particular team
 (defresource team [conn team-id]
@@ -313,7 +316,8 @@
 
   ;; Existentialism
   :exists? (fn [ctx] (if-let [team (and (lib-schema/unique-id? team-id) (team-res/get-team conn team-id))]
-                        {:existing-team team}
+                        {:existing-team team
+                         :invite-throttle (invite-throttle/get-or-create! (:user-id (:user ctx)) team-id)}
                         false))
 
   ;; Actions
@@ -333,17 +337,28 @@
                                           (slack-org-res/list-slack-orgs-by-ids conn slack-org-ids
                                             [:bot-user-id :bot-token]))
                              full-user (user-res/get-user conn (:user-id (:user ctx)))]
-                          (team-rep/render-team (assoc team-users :slack-orgs slack-orgs) full-user)))
+                          (team-rep/render-team (assoc team-users :slack-orgs slack-orgs) full-user (:invite-throttle ctx))))
   :handle-unprocessable-entity (fn [ctx]
     (api-common/unprocessable-entity-handler (merge ctx {:reason (schema/check team-res/Team (:team-update ctx))}))))
 
 
-(defn- can-invite? [ctx]
-  (-> ctx :user :status keyword (= :active)))
+(defn- can-invite? [ctx conn]
+  (let [check-user-status #(-> % :status keyword (= :active))]
+    (if (-> ctx :user :status)
+      (check-user-status (:user ctx))
+      (check-user-status (user-res/get-user conn (:user-id (:user ctx)))))))
+
+(defn- check-invite-throttle [token invite-throttle-data]
+  (and (= token (:token invite-throttle-data))
+       (< (:invite-count invite-throttle-data) config/invite-throttle-max-count)))
 
 ;; A resource for user invitations to a particular team
 (defresource invite [conn team-id]
   (api-common/open-company-authenticated-resource config/passphrase) ; verify validity and presence of required JWToken
+
+  :initialize-context (fn [ctx] (let [jwt-auth (api-common/read-token (:request ctx) config/passphrase)
+                                      invite-throttle-data (when (:user jwt-auth) (invite-throttle/retrieve (-> jwt-auth :user :user-id) team-id))]
+                                  (merge jwt-auth {:invite-throttle invite-throttle-data})))
 
   :allowed-methods [:options :post]
 
@@ -359,7 +374,7 @@
   ;; Authorization
   :allowed? (by-method {
     :options true
-    :post (fn [ctx] (when (can-invite? ctx)
+    :post (fn [ctx] (when (can-invite? ctx conn)
                       (if (-> ctx :data :admin)
                         (allow-team-admins conn (:user ctx) team-id)
                         (allow-team-members conn (:user ctx) team-id))))})
@@ -379,7 +394,8 @@
   ;; Validations
   :processable? (by-method {
     :options true
-    :post (fn [ctx] (or (lib-schema/valid? team-res/EmailInviteRequest (:data ctx))
+    :post (fn [ctx] (or (and (lib-schema/valid? team-res/EmailInviteRequest (:data ctx))
+                             (check-invite-throttle (-> ctx :data :csrf) invite-throttle-data))
                         (lib-schema/valid? team-res/SlackInviteRequest (:data ctx))))})
 
   ;; Actions
@@ -391,14 +407,16 @@
                       (:existing-user ctx) ; recipient
                       (:member? ctx)
                       (:admin? ctx)
-                      (:data ctx))}) ; invitation
+                      (dissoc (:data ctx) :csrf))}) ; invitation
 
   ;; Responses
   :respond-with-entity? true
   :handle-created (fn [ctx] (if-let [updated-user (:updated-user ctx)]
-                              (api-common/location-response (user-rep/url updated-user)
+                              (do
+                                (invite-throttle/increase-invite-count! (-> ctx :user :user-id) team-id)
+                                (api-common/location-response (user-rep/url updated-user)
                                                             (user-rep/render-user updated-user)
-                                                            mt/user-media-type)
+                                                            mt/user-media-type))
                               (api-common/missing-response))))
 
 ;; A resource for the admins of a particular team
@@ -497,8 +515,8 @@
   ;; Authorization
   :allowed? (by-method {
     :options true
-    :post (fn [ctx] (when (can-invite? ctx) (allow-team-admins conn (:user ctx) team-id)))
-    :delete (fn [ctx] (when (can-invite? ctx) (allow-team-admins conn (:user ctx) team-id)))})
+    :post (fn [ctx] (when (can-invite? ctx conn) (allow-team-admins conn (:user ctx) team-id)))
+    :delete (fn [ctx] (when (can-invite? ctx conn) (allow-team-admins conn (:user ctx) team-id)))})
 
   :processable? (fn [ctx] (team-res/allowed-email-domain? (:email-domain (:data ctx)))) ; check for blacklisted email domain
 
@@ -664,14 +682,15 @@
   ;; Authorization
   :allowed? (by-method {
     :options true
-    :post (fn [ctx] (when (can-invite? ctx) (allow-team-admins conn (:user ctx) team-id)))
-    :delete (fn [ctx] (when (can-invite? ctx) (allow-team-admins conn (:user ctx) team-id)))})
+    :post (fn [ctx] (when (can-invite? ctx conn) (allow-team-admins conn (:user ctx) team-id)))
+    :delete (fn [ctx] (when (can-invite? ctx conn) (allow-team-admins conn (:user ctx) team-id)))})
 
   ;; Existentialism
   :exists? (fn [ctx]
               (if-let* [team (and (lib-schema/unique-id? team-id) (team-res/get-team conn team-id))
                         _invite-link (:invite-token team)]
-                {:existing-team team}
+                {:existing-team team
+                 :invite-throttle (invite-throttle/get-or-create! (:user-id (:user ctx)) team-id)}
                 false)) ; No team by that ID or invite-token already exists
 
   ;; Validations
@@ -687,10 +706,10 @@
   :post-enacted? true
   :handle-created (fn [ctx]
                     (let [full-user (user-res/get-user conn (:user-id (:user ctx)))]
-                      (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)) full-user)))
+                      (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)) full-user (:invite-throttle ctx))))
   :handle-ok (fn [ctx]
                (let [full-user (user-res/get-user conn (:user-id (:user ctx)))]
-                 (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)) full-user))))
+                 (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)) full-user (:invite-throttle ctx)))))
 
 ;; A resource for roster of team users for a particular team
 (defresource active-users [conn team-id]

--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -395,7 +395,7 @@
   :processable? (by-method {
     :options true
     :post (fn [ctx] (or (and (lib-schema/valid? team-res/EmailInviteRequest (:data ctx))
-                             (check-invite-throttle (-> ctx :data :csrf) invite-throttle-data))
+                             (check-invite-throttle (-> ctx :data :csrf) (:invite-throttle ctx)))
                         (lib-schema/valid? team-res/SlackInviteRequest (:data ctx))))})
 
   ;; Actions

--- a/src/oc/auth/api/teams.clj
+++ b/src/oc/auth/api/teams.clj
@@ -332,7 +332,7 @@
                                           []
                                           (slack-org-res/list-slack-orgs-by-ids conn slack-org-ids
                                             [:bot-user-id :bot-token]))]
-                          (team-rep/render-team (assoc team-users :slack-orgs slack-orgs))))
+                          (team-rep/render-team (assoc team-users :slack-orgs slack-orgs) (:user ctx))))
   :handle-unprocessable-entity (fn [ctx]
     (api-common/unprocessable-entity-handler (merge ctx {:reason (schema/check team-res/Team (:team-update ctx))}))))
 
@@ -681,9 +681,9 @@
   :respond-with-entity? true
   :post-enacted? true
   :handle-created (fn [ctx]
-                    (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx))))
+                    (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)) (:user ctx)))
   :handle-ok (fn [ctx]
-               (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)))))
+               (team-rep/render-team (or (:updated-team ctx) (:existing-team ctx)) (:user ctx))))
 
 ;; A resource for roster of team users for a particular team
 (defresource active-users [conn team-id]

--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -171,3 +171,17 @@
 (defonce digest-times (set (map keyword (clojure.string/split (or (env :digest-times) "700") #","))))
 (defonce premium-digest-times (set (map keyword (clojure.string/split (or (env :premium-digest-times) "700,1200,1700") #","))))
 (defonce default-digest-time (keyword (or (env :default-digest-time) "700")))
+
+;; ----- DynamoDB -----
+
+(defonce dynamodb-end-point (or (env :dynamodb-end-point) "http://localhost:8000"))
+
+(defonce dynamodb-table-prefix (or (env :dynamodb-table-prefix) "local"))
+
+(defonce dynamodb-opts {:access-key (env :aws-access-key-id)
+                        :secret-key (env :aws-secret-access-key)
+                        :endpoint dynamodb-end-point})
+
+(defonce invite-throttle-ttl (or (env :invite-throttle-ttl) 1)) ;; hours
+
+(defonce invite-throttle-max-count (or (env :invite-throttle-max-count) 100)) ;; hours

--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -182,6 +182,6 @@
                         :secret-key (env :aws-secret-access-key)
                         :endpoint dynamodb-end-point})
 
-(defonce invite-throttle-ttl (or (env :invite-throttle-ttl) 1)) ;; hours
+(defonce invite-throttle-ttl (Integer/parseInt (or (env :invite-throttle-ttl-hours) "1"))) ;; hours
 
-(defonce invite-throttle-max-count (or (env :invite-throttle-max-count) 10)) ;; 10 invites at most every invite-throttle-ttl
+(defonce invite-throttle-max-count (Integer/parseInt (or (env :invite-throttle-max-count) "100"))) ;; 100 invites at most every invite-throttle-ttl

--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -182,6 +182,6 @@
                         :secret-key (env :aws-secret-access-key)
                         :endpoint dynamodb-end-point})
 
-(defonce invite-throttle-ttl (Integer/parseInt (or (env :invite-throttle-ttl-hours) "1"))) ;; hours
+(defonce invite-throttle-ttl-hours (Integer/parseInt (or (env :invite-throttle-ttl-hours) "1"))) ;; hours
 
-(defonce invite-throttle-max-count (Integer/parseInt (or (env :invite-throttle-max-count) "100"))) ;; 100 invites at most every invite-throttle-ttl
+(defonce invite-throttle-max-count (Integer/parseInt (or (env :invite-throttle-max-count) "100"))) ;; 100 invites at most every invite-throttle-ttl-hours

--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -182,6 +182,6 @@
                         :secret-key (env :aws-secret-access-key)
                         :endpoint dynamodb-end-point})
 
-(defonce invite-throttle-ttl-hours (Integer/parseInt (or (env :invite-throttle-ttl-hours) "1"))) ;; hours
+(defonce invite-throttle-ttl-minutes (Integer/parseInt (or (env :invite-throttle-ttl-minutes) "60"))) ;; minutes
 
-(defonce invite-throttle-max-count (Integer/parseInt (or (env :invite-throttle-max-count) "100"))) ;; 100 invites at most every invite-throttle-ttl-hours
+(defonce invite-throttle-max-count (Integer/parseInt (or (env :invite-throttle-max-count) "100"))) ;; 100 invites at most every invite-throttle-ttl-minutes

--- a/src/oc/auth/config.clj
+++ b/src/oc/auth/config.clj
@@ -184,4 +184,4 @@
 
 (defonce invite-throttle-ttl (or (env :invite-throttle-ttl) 1)) ;; hours
 
-(defonce invite-throttle-max-count (or (env :invite-throttle-max-count) 100)) ;; hours
+(defonce invite-throttle-max-count (or (env :invite-throttle-max-count) 10)) ;; 10 invites at most every invite-throttle-ttl

--- a/src/oc/auth/db/migrations/1660231672606_add_invite_throttle_table.edn
+++ b/src/oc/auth/db/migrations/1660231672606_add_invite_throttle_table.edn
@@ -1,0 +1,10 @@
+(ns oc.auth.db.migrations.add-invite-throttle-table
+  (:require [rethinkdb.query :as r]
+            [oc.lib.db.migrations :as m]
+            [oc.auth.config :as config]
+            [oc.auth.resources.invite-throttle :as invite-throttle]))
+
+(defn up [dynamodb-opts]
+  ;; Do great things
+  (println (invite-throttle/create-table dynamodb-opts))
+  true) ; return true on success

--- a/src/oc/auth/db/migrations/1660231672606_add_invite_throttle_table.edn
+++ b/src/oc/auth/db/migrations/1660231672606_add_invite_throttle_table.edn
@@ -1,10 +1,17 @@
 (ns oc.auth.db.migrations.add-invite-throttle-table
-  (:require [rethinkdb.query :as r]
+  (:require [taoensso.faraday :as far]
             [oc.lib.db.migrations :as m]
             [oc.auth.config :as config]
             [oc.auth.resources.invite-throttle :as invite-throttle]))
 
 (defn up [dynamodb-opts]
   ;; Do great things
-  (println (invite-throttle/create-table dynamodb-opts))
+    ;; Create invite-throttle table if not already present
+  (println
+   (far/ensure-table dynamodb-opts
+                     invite-throttle/table-name
+                     [:user_id :s]
+                     {:range-keydef [:team_id :s]
+                      :billing-mode :pay-per-request
+                      :block? true}))
   true) ; return true on success

--- a/src/oc/auth/db/migrations/1660231672606_add_invite_throttle_table.edn
+++ b/src/oc/auth/db/migrations/1660231672606_add_invite_throttle_table.edn
@@ -2,16 +2,19 @@
   (:require [taoensso.faraday :as far]
             [oc.lib.db.migrations :as m]
             [oc.auth.config :as config]
+            [oc.lib.dynamo.common :as ttl]
             [oc.auth.resources.invite-throttle :as invite-throttle]))
 
-(defn up [dynamodb-opts]
+(defn up [_]
   ;; Do great things
     ;; Create invite-throttle table if not already present
   (println
-   (far/ensure-table dynamodb-opts
+   (far/ensure-table config/dynamodb-opts
                      invite-throttle/table-name
                      [:user_id :s]
                      {:range-keydef [:team_id :s]
                       :billing-mode :pay-per-request
                       :block? true}))
+  (println
+   (ttl/maybe-enable-ttl config/dynamodb-opts invite-throttle/table-name))
   true) ; return true on success

--- a/src/oc/auth/representations/team.clj
+++ b/src/oc/auth/representations/team.clj
@@ -38,6 +38,7 @@
                      :accept mt/user-media-type}
                     {:csrf (:token invite-throttle)
                      :invite-count (:invite-count invite-throttle)
+                     :ttl (:ttl invite-throttle)
                      :total-invites config/invite-throttle-max-count}))
 
 (defn- payments-link [team-id]

--- a/src/oc/auth/representations/team.clj
+++ b/src/oc/auth/representations/team.clj
@@ -72,16 +72,19 @@
 
 (defn- admin-links
   "HATEOAS links for a team resource for a team admin."
-  ([team] (admin-links team nil))
+  ([team] (admin-links team nil nil))
   
-  ([team self-name]
-  (let [team-id (:team-id team)]
+  ([team user] (admin-links team user nil))
+  
+  ([team user self-name]
+  (let [team-id (:team-id team)
+        can-invite? (-> user :status keyword (= :active))]
     (assoc team :links [
       (if self-name 
         (hateoas/link-map self-name hateoas/GET (url team-id) {:accept mt/team-media-type})
         (self-link team-id))
       (partial-update-link team-id)
-      (invite-user-link team-id)
+      (when can-invite? (invite-user-link team-id))
       (add-email-domain-link team-id)
       (add-slack-org-link team-id)
       (add-slack-bot-link team-id)
@@ -91,11 +94,12 @@
       (channels-link team-id)
       (when config/payments-enabled?
         (payments-link team-id))
-      (when (seq (:invite-token team))
+      (when (and can-invite? (seq (:invite-token team)))
         (invite-token-link (:invite-token team)))
-      (if (seq (:invite-token team))
-        (delete-invite-token-link team-id)
-        (create-invite-token-link team-id))]))))
+      (when can-invite?
+        (if (seq (:invite-token team))
+          (delete-invite-token-link team-id)
+          (create-invite-token-link team-id)))]))))
 
 (defn- id-token-links
   "HATEOAS links for a team resource for a user authenticated with the id-token only."
@@ -134,14 +138,14 @@
 
 (defn render-team
   "Given a team map, create a JSON representation of the team for the REST API."
-  [team]
+  [team user]
   (let [team-id (:team-id team)]
     (json/generate-string
       (-> team
         (select-keys representation-props)
         (assoc :email-domains (map #(email-domain team-id %) (:email-domains team)))
         (assoc :slack-orgs (map #(slack-org team-id %) (:slack-orgs team)))
-        (admin-links))
+        (admin-links user))
       {:pretty config/pretty?})))
 
 (defn render-team-list
@@ -158,7 +162,7 @@
                   :items (->> teams
                             (map #(cond
                                     (:id-token user) (id-token-links %)
-                                    ((set (:admins %)) (:user-id user)) (admin-links % "item")
+                                    ((set (:admins %)) (:user-id user)) (admin-links % user "item")
                                     :else (member-links %)))
                             (map #(dissoc % :admins)))}}
     {:pretty config/pretty?}))

--- a/src/oc/auth/representations/team.clj
+++ b/src/oc/auth/representations/team.clj
@@ -79,7 +79,7 @@
   ([team user self-name]
   (let [team-id (:team-id team)
         can-invite? (-> user :status keyword (= :active))]
-    (assoc team :links [
+    (assoc team :links (remove nil? [
       (if self-name 
         (hateoas/link-map self-name hateoas/GET (url team-id) {:accept mt/team-media-type})
         (self-link team-id))
@@ -99,7 +99,7 @@
       (when can-invite?
         (if (seq (:invite-token team))
           (delete-invite-token-link team-id)
-          (create-invite-token-link team-id)))]))))
+          (create-invite-token-link team-id)))])))))
 
 (defn- id-token-links
   "HATEOAS links for a team resource for a user authenticated with the id-token only."

--- a/src/oc/auth/representations/team.clj
+++ b/src/oc/auth/representations/team.clj
@@ -32,9 +32,13 @@
 (defn- remove-email-domain-link [team-id domain]
   (hateoas/remove-link (s/join "/" [(url team-id) "email-domains" domain]) {} {:ref mt/email-domain-media-type}))
 
-(defn- invite-user-link [team-id]
-  (hateoas/add-link hateoas/POST (str (url team-id) "/users/") {:content-type mt/invite-media-type
-                                                                :accept mt/user-media-type}))
+(defn- invite-user-link [team-id invite-throttle]
+  (hateoas/add-link hateoas/POST (str (url team-id) "/users/")
+                    {:content-type mt/invite-media-type
+                     :accept mt/user-media-type}
+                    {:csrf (:token invite-throttle)
+                     :invite-count (:invite-count invite-throttle)
+                     :total-invites config/invite-throttle-max-count}))
 
 (defn- payments-link [team-id]
   (hateoas/link-map
@@ -72,11 +76,13 @@
 
 (defn- admin-links
   "HATEOAS links for a team resource for a team admin."
-  ([team] (admin-links team nil nil))
+  ([team] (admin-links team nil nil nil))
   
-  ([team user] (admin-links team user nil))
+  ([team user] (admin-links team user nil nil))
   
-  ([team user self-name]
+  ([team user self-name] (admin-links team user self-name nil))
+
+  ([team user self-name invite-throttle]
   (let [team-id (:team-id team)
         can-invite? (-> user :status keyword (= :active))]
     (assoc team :links (remove nil? [
@@ -84,7 +90,7 @@
         (hateoas/link-map self-name hateoas/GET (url team-id) {:accept mt/team-media-type})
         (self-link team-id))
       (partial-update-link team-id)
-      (when can-invite? (invite-user-link team-id))
+      (when can-invite? (invite-user-link team-id invite-throttle))
       (add-email-domain-link team-id)
       (add-slack-org-link team-id)
       (add-slack-bot-link team-id)
@@ -108,10 +114,11 @@
 
 (defn- member-links
   "HATEOAS links for a team resource for a regular team member."
-  [{team-id :team-id :as team}]
-  (assoc team :links [(roster-link team-id)
-                      (invite-user-link team-id)
-                      (channels-link team-id)]))
+  [{team-id :team-id :as team} user invite-throttle]
+  (let [can-invite? (-> user :status keyword (= :active))]
+    (assoc team :links [(roster-link team-id)
+                        (when can-invite? (invite-user-link team-id invite-throttle))
+                        (channels-link team-id)])))
 
 (defn- email-domain
   "Item entry for an email domain for the team."
@@ -138,14 +145,14 @@
 
 (defn render-team
   "Given a team map, create a JSON representation of the team for the REST API."
-  [team user]
+  [team user invite-throttle]
   (let [team-id (:team-id team)]
     (json/generate-string
       (-> team
         (select-keys representation-props)
         (assoc :email-domains (map #(email-domain team-id %) (:email-domains team)))
         (assoc :slack-orgs (map #(slack-org team-id %) (:slack-orgs team)))
-        (admin-links user))
+        (admin-links user nil invite-throttle))
       {:pretty config/pretty?})))
 
 (defn render-team-list
@@ -162,7 +169,7 @@
                   :items (->> teams
                             (map #(cond
                                     (:id-token user) (id-token-links %)
-                                    ((set (:admins %)) (:user-id user)) (admin-links % user "item")
-                                    :else (member-links %)))
-                            (map #(dissoc % :admins)))}}
+                                    ((set (:admins %)) (:user-id user)) (admin-links % user "item" (:invite-throttle %))
+                                    :else (member-links % user (:invite-throttle %))))
+                            (map #(apply dissoc % [:admins :invite-throttle])))}}
     {:pretty config/pretty?}))

--- a/src/oc/auth/resources/invite_throttle.clj
+++ b/src/oc/auth/resources/invite_throttle.clj
@@ -6,6 +6,7 @@
             [schema.core :as schema]
             [oc.lib.schema :as lib-schema]
             [oc.auth.config :as c]
+            [clj-time.core :as clj-time]
             [oc.lib.dynamo.common :as ttl]))
 
 ;; ----- DynamoDB -----
@@ -42,8 +43,6 @@
 
 ;; ----- TTL -----
 
-(def invite-throttle-ttl (ttl/ttl-epoch (* (/ 1 24) c/invite-throttle-ttl-hours))
-
 ;; ----- Constructors -----
 
 (schema/defn ^:always-validate ->InviteThrottle :- InviteThrottle
@@ -62,7 +61,7 @@
    :team-id team-id
    :token token
    :invite-count invite-count
-   :ttl invite-throttle-ttl}))
+   :ttl c/invite-throttle-ttl-hours}))
 
 ;; ----- DB Operations -----
 
@@ -72,7 +71,7 @@
       (clj-set/rename-keys {:user-id :user_id
                             :team-id :team_id
                             :invite-count :invite_count})
-      (assoc :ttl (or (:ttl invite-throttle-data) (ttl/ttl-epoch c/invite-throttle-ttl)))))
+      (assoc :ttl (or (:ttl invite-throttle-data) (ttl/ttl-epoch c/invite-throttle-ttl-hours clj-time/hours)))))
 
 (schema/defn ^:always-validate store!
   ([user-id :- lib-schema/UniqueID

--- a/src/oc/auth/resources/invite_throttle.clj
+++ b/src/oc/auth/resources/invite_throttle.clj
@@ -96,8 +96,7 @@
   (-> (far/get-item c/dynamodb-opts table-name {:user_id user-id :team_id team-id})
       (clj-set/rename-keys {:user_id :user-id
                             :team_id :team-id
-                            :invite_count :invite-count})
-      (dissoc :ttl)))
+                            :invite_count :invite-count})))
 
 (schema/defn ^:always-validate delete!
   [user-id :- lib-schema/UniqueID

--- a/src/oc/auth/resources/invite_throttle.clj
+++ b/src/oc/auth/resources/invite_throttle.clj
@@ -40,6 +40,10 @@
   (schema/optional-key :ttl) schema/Num
 })
 
+;; ----- TTL -----
+
+(def invite-throttle-ttl (ttl/ttl-epoch (* (/ 1 24) c/invite-throttle-ttl-hours))
+
 ;; ----- Constructors -----
 
 (schema/defn ^:always-validate ->InviteThrottle :- InviteThrottle
@@ -58,7 +62,7 @@
    :team-id team-id
    :token token
    :invite-count invite-count
-   :ttl (ttl/ttl-epoch c/invite-throttle-ttl)}))
+   :ttl invite-throttle-ttl}))
 
 ;; ----- DB Operations -----
 

--- a/src/oc/auth/resources/invite_throttle.clj
+++ b/src/oc/auth/resources/invite_throttle.clj
@@ -136,7 +136,8 @@
                           :return :updated-new}))
     (do
       (timbre/debugf "No item found for %s %s, will create one" user-id team-id)
-      (store! (->InviteThrottle user-id team-id)))))
+      (store! (->InviteThrottle user-id team-id))))
+  (retrieve user-id team-id))
 
 (schema/defn ^:always-validate get-or-create! :- InviteThrottle
   [user-id :- lib-schema/UniqueID

--- a/src/oc/auth/resources/invite_throttle.clj
+++ b/src/oc/auth/resources/invite_throttle.clj
@@ -43,6 +43,9 @@
 
 ;; ----- TTL -----
 
+(defn- default-invite-throttle-ttl []
+  (ttl/ttl-epoch c/invite-throttle-ttl-hours clj-time/hours))
+
 ;; ----- Constructors -----
 
 (schema/defn ^:always-validate ->InviteThrottle :- InviteThrottle
@@ -61,7 +64,7 @@
    :team-id team-id
    :token token
    :invite-count invite-count
-   :ttl c/invite-throttle-ttl-hours}))
+   :ttl (default-invite-throttle-ttl)}))
 
 ;; ----- DB Operations -----
 
@@ -71,7 +74,7 @@
       (clj-set/rename-keys {:user-id :user_id
                             :team-id :team_id
                             :invite-count :invite_count})
-      (assoc :ttl (or (:ttl invite-throttle-data) (ttl/ttl-epoch c/invite-throttle-ttl-hours clj-time/hours)))))
+      (assoc :ttl (or (:ttl invite-throttle-data) (default-invite-throttle-ttl)))))
 
 (schema/defn ^:always-validate store!
   ([user-id :- lib-schema/UniqueID

--- a/src/oc/auth/resources/invite_throttle.clj
+++ b/src/oc/auth/resources/invite_throttle.clj
@@ -1,0 +1,140 @@
+(ns oc.auth.resources.invite-throttle
+  "Store notification details with a TTL"
+  (:require [taoensso.faraday :as far]
+            [clojure.set :as clj-set]
+            [schema.core :as schema]
+            [oc.lib.schema :as lib-schema]
+            [oc.auth.config :as c]
+            [oc.lib.dynamo.common :as ttl]))
+
+;; ----- DynamoDB -----
+
+(def table-name (keyword (str c/dynamodb-table-prefix "_invite_throttle")))
+
+;; {
+;;  :user-id "1234-1234-1234"
+;;  :team-id "1234-1234-1234"
+;;  :token "4321-4321-4321"
+;;  :invites-count 0
+;;  :ttl 123456789
+;; }
+
+;; ----- Schema -----
+
+(def user-key-reg-ex #"^team-(\d|[a-f]){4}-(\d|[a-f]){4}-(\d|[a-f]){4}-user-(\d|[a-f]){4}-(\d|[a-f]){4}-(\d|[a-f]){4}$")
+
+(defn user-key?
+  "Is this a user-key unique ID? ie: team-1234-1234-1234-user-1234-2134-1234"
+  [s]
+  (if (and s (string? s) (re-matches user-key-reg-ex s)) true false))
+
+(def UserKey
+  (schema/pred user-key?))
+
+(def InviteThrottle {
+  :user-id lib-schema/UniqueID
+  :team-id lib-schema/UniqueID
+  :token lib-schema/UUIDStr
+  :invite-count schema/Num
+  (schema/optional-key :ttl) schema/Num
+})
+
+;; ----- Constructors -----
+
+(schema/defn ^:always-validate ->InviteThrottle :- InviteThrottle
+  ([user-id :- lib-schema/UniqueID
+    team-id :- lib-schema/UniqueID]
+   (->InviteThrottle user-id team-id (str (java.util.UUID/randomUUID)) 0))
+  ([user-id :- lib-schema/UniqueID
+    team-id :- lib-schema/UniqueID
+    invite-count :- schema/Num]
+   (->InviteThrottle user-id team-id (str (java.util.UUID/randomUUID)) invite-count))
+  ([user-id :- lib-schema/UniqueID
+    team-id :- lib-schema/UniqueID
+    token :- lib-schema/UUIDStr
+    invite-count :- schema/Num]
+  {:user-id user-id
+   :team-id team-id
+   :token token
+   :invite-count invite-count
+   :ttl (ttl/ttl-epoch c/invite-throttle-ttl)}))
+
+;; ----- DB Operations -----
+
+(defn- transform-invite-throttle
+  [invite-throttle-data]
+  (-> invite-throttle-data
+      (clj-set/rename-keys {:user-id :user_id
+                            :team-id :team_id
+                            :invite-count :invite_count})
+      (assoc :ttl (or (:ttl invite-throttle-data) (ttl/ttl-epoch c/invite-throttle-ttl)))))
+
+(schema/defn ^:always-validate store!
+  [invite-throttle-data :- InviteThrottle]
+  (far/put-item c/dynamodb-opts table-name (transform-invite-throttle invite-throttle-data))
+  true)
+
+(schema/defn ^:always-validate retrieve :- InviteThrottle
+  [user-id :- lib-schema/UniqueID
+   team-id :- lib-schema/UniqueID]
+  ;; Filter out TTL records as TTL expiration doesn't happen with local DynamoDB,
+  ;; and on server DynamoDB it can be delayed by up to 48 hours
+  (-> (far/get-item c/dynamodb-opts table-name {:user_id user-id :team_id team-id})
+      (clj-set/rename-keys {:user_id :user-id
+                            :team_id :team-id
+                            :invite_count :invite-count})
+      (dissoc :ttl)))
+
+(schema/defn ^:always-validate increase-invite-count! :- schema/Bool
+  [user-id :- lib-schema/UniqueID
+   team-id :- lib-schema/UniqueID]
+  (let [current-record (retrieve user-id team-id)
+        new-record (if current-record
+                     (update current-record :invite-count inc)
+                     (->InviteThrottle user-id team-id 1))]
+    (store! new-record)))
+
+(defn create-table
+  ([] (create-table c/dynamodb-opts))
+
+  ([dynamodb-opts]
+   (far/ensure-table dynamodb-opts table-name
+                     [:user_id :s]
+                     {:range-keydef [:team_id :s]
+                      :billing-mode :pay-per-request
+                      :block? true})))
+
+(defn delete-table
+  ([] (delete-table c/dynamodb-opts))
+
+  ([dynamodb-opts]
+   (far/delete-table dynamodb-opts table-name)))
+
+(defn delete-all! []
+  (delete-table)
+  (create-table))
+
+(comment
+  (require '[oc.auth.resources.invite-throttle :as invite-throttle] :reload)
+
+  (far/list-tables c/dynamodb-opts)
+
+  (far/delete-table c/dynamodb-opts invite-throttle/table-name)
+
+  (aprint
+   (far/create-table c/dynamodb-opts
+                     invite-throttle/table-name
+                     [:user_id :s]
+                     {:range-keydef [:team_id :s]
+                      :billing-mode :pay-per-request
+                      :block? true}))
+
+  (aprint (far/describe-table c/dynamodb-opts invite-throttle/table-name))
+
+  (def user-id "1234-5678-1234")
+  (def team-id "1234-6463-2563")
+
+  (def it1 (invite-throttle/->InviteThrottle user-id team-id))
+  (invite-throttle/store! it1)
+  (invite-throttle/increase-invite-count! user-id team-id)
+  (invite-throttle/retrieve user-id team-id))

--- a/src/oc/auth/resources/invite_throttle.clj
+++ b/src/oc/auth/resources/invite_throttle.clj
@@ -73,8 +73,8 @@
 (schema/defn ^:always-validate store!
   ([user-id :- lib-schema/UniqueID
     team-id :- lib-schema/UniqueID]
-   (store! (->InviteThrottle user-id team-id))
-   true)
+  (store! (->InviteThrottle user-id team-id))
+  true)
 
   ([invite-throttle-data :- InviteThrottle]
   (timbre/debugf "Store invite-throttle for %s %s" (:user-id invite-throttle-data) (:team-id invite-throttle-data))
@@ -131,6 +131,15 @@
     (do
       (timbre/debugf "No item found for %s %s, will create one" user-id team-id)
       (store! (->InviteThrottle user-id team-id)))))
+
+(schema/defn ^:always-validate get-or-create! :- InviteThrottle
+  [user-id :- lib-schema/UniqueID
+   team-id :- lib-schema/UniqueID]
+  (if-let [existing-item (retrieve user-id team-id)]
+    existing-item
+    (do
+      (store! user-id team-id)
+      (retrieve user-id team-id))))
 
 ;; ----- Table handling -----
 

--- a/src/oc/auth/resources/invite_throttle.clj
+++ b/src/oc/auth/resources/invite_throttle.clj
@@ -44,7 +44,7 @@
 ;; ----- TTL -----
 
 (defn- default-invite-throttle-ttl []
-  (ttl/ttl-epoch c/invite-throttle-ttl-hours clj-time/hours))
+  (ttl/ttl-epoch c/invite-throttle-ttl-minutes clj-time/minutes))
 
 ;; ----- Constructors -----
 

--- a/src/oc/auth/resources/team.clj
+++ b/src/oc/auth/resources/team.clj
@@ -33,6 +33,7 @@
 (def EmailInviteRequest {
   :email lib-schema/EmailAddress
   :admin schema/Bool
+  :csrf schema/Str
   (schema/optional-key :org-name) (schema/maybe schema/Str)
   (schema/optional-key :org-uuid) (schema/maybe schema/Str)
   (schema/optional-key :org-slug) (schema/maybe schema/Str)
@@ -49,6 +50,7 @@
   :slack-id lib-schema/NonBlankStr
   :slack-org-id lib-schema/NonBlankStr
   :admin schema/Bool
+  (schema/optional-key :csrf) (schema/maybe schema/Str)
   (schema/optional-key :org-name) (schema/maybe schema/Str)
   (schema/optional-key :org-uuid) (schema/maybe schema/Str)
   (schema/optional-key :org-slug) (schema/maybe schema/Str)


### PR DESCRIPTION
#### Card: https://trello.com/c/YBJz95A6

#### Related PRs (review together):
- [Web PR](https://github.com/open-company/open-company-web/pull/1182)
- [Lib PR](https://github.com/open-company/open-company-lib/pull/88)
- [Support PR](https://github.com/open-company/open-company-support/pull/1)

#### Description of the change:
To prevent future suspension of our SES account we want to improve even more the limitation around user invitation.
These PRs are meant to add a limit of the number of invites a user can send in a certain amount of time and also add a CSRF token that will prevent cross-site calls of our invite API.

The whole thing is based on a Dynamodb table that has user-id as key, team-id as range key, then it contains a token column that is the CSRF token and number of invites sent in the current period.

The ttl will make sure this record expire when we want so the count will be reset to 0. The keys will make sure the limitation is applied by user/team not to a certain user on all the teams he has (no need to test or get into this, we don't have multiple teams customers right now).

The CSRF token is refreshed every time the user request the invite link, that means only 1 session at the time will be able to send invites.

NB: all this is on staging but with lower limits for easy tests. On staging you can send 10 invites every 10 minutes. On production it's 100 invites every hour. You can test this on staging if you want, just remember to use real emails (or at least emails that seems real because there is also the recipient validation PR deployed there which will fail inviting users with fake emails).

To test:
- sign in with your stoatlabs Slack account
- [ ] try inviting a user: did it work? Good
- now invite another 9 users in less than 10 minutes
- invite another user
- [ ] did it fail? Good
- wait 10 minutes from the first invite sent
- try inviting another user now
- [ ] did it work? Good
- now fill in the email of a user to invite
- copy the url of the current page
- open a new tab and paste it (use the same browser session)
- open the invite panel
- go back to the initial tab and try inviting
- [ ] did it fail? Good (if it doesn't fails it means the client refreshed the team data which refresh the CSRF token, sometimes that happens automatically depending on a few factors)

This should be it, please drop me a note when this is merged since I need to do a bit of cleanup in the infra repo (deployed branch mostly).